### PR TITLE
Add basic Tekton docs 📝

### DIFF
--- a/.github/issue-template.md
+++ b/.github/issue-template.md
@@ -1,0 +1,16 @@
+---
+name: Issue Template
+about: Template for both bug reports and feature requests
+---
+
+# Expected Behavior
+
+# Actual Behavior
+
+# Steps to Reproduce the Problem
+
+1.
+2.
+3.
+
+# Additional Info

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
+
+# Changes
+
+<!-- Describe your changes here- ideally you can get that description straight from
+your descriptive commit message(s)! -->
+
+# Submitter Checklist
+
+These are the criteria that every PR should meet, please check them off as you
+review them:
+
+- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
+- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
+
+_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
+for more details._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to the Tekton website
+
+Thanks for considering contributing to our project!
+
+**All contributors must comply with
+[the code of conduct](./code-of-conduct.md).**
+
+To get started developing, see our [DEVELOPMENT.md](./DEVELOPMENT.md).
+
+- The [OWNERS](OWNERS) of this repo are the
+  [members of the Tekton governing board](https://github.com/tektoncd/community/blob/master/governance.md)
+  as well as folks from the Linux Foundation who contribute to this project.
+
+In [the community repo](https://github.com/tektoncd/community) you'll find info
+on:
+
+- [Contacting other contributors](https://github.com/tektoncd/community/blob/master/contact.md)
+- [Development standards](https://github.com/tektoncd/community/blob/master/standards.md)
+  including standards for 
+  [commit messages](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
+- [Processes](https://github.com/tektoncd/community/blob/master/process.md) like
+  [reviews](https://github.com/tektoncd/community/blob/master/process.md#reviews)
+
+You can find details on our automation infrastructure in
+[the plumbing repo](https://github.com/tektoncd/plumbing).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,30 @@
+# Developing the Tekton website
+
+- [Setting up your dev environment](#setup)
+- [Deploying changes](#deploying)
+
+## Setup
+
+Before working on website issues, be sure to have the following installed:
+
+- [Yarn](https://yarnpkg.com/en/)
+- [Hugo](https://gohugo.io/)
+
+You can [use the `hugo` command](https://gohugo.io/getting-started/usage/)
+to interact with the site locally and see the results
+[before deploying](#deploying).
+
+## Deploying
+
+At the moment, deployments are done manually after a merge to master.
+Eventually we plan to move to [netlify](https://www.netlify.com/) (once we
+transfer ownership of the `tekton.dev` domain to the Linux Foundation),
+which would provide us with gitops based automation.
+
+- Currently we are hosting `tekton.dev` on [firebase](https://firebase.google.com/)
+- The `firebase` project is called `tekton`
+- [Members of the Tekton governing board](https://github.com/tektoncd/community/blob/master/governance.md)
+  and other Linux Foundation contributors have access to the firebase project
+
+Instructions for deploying Hugo based sites to Firebase:
+https://gohugo.io/hosting-and-deployment/hosting-on-firebase/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
-# Quick Start Guide
+# TektonCD Website
 
-Before working on website issues, be sure to have the following installed:
-- [Yarn](https://yarnpkg.com/en/)
-- [Hugo](https://gohugo.io/)
+This repo contains the code behind [the Tekton org's](https://github.com/tektoncd)
+website at [tekton.dev](https://tekton.dev).
+
+For more information on the Tekton Project, see
+[the community repo](https://github.com/tektoncd/community).
+
+For more information on contributing to the website see:
+
+* [CONTRIBUTING.md](CONTRIBUTING.md)
+* [DEVELOPMENT.md](DEVELOPMENT.md)

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at
+tekton-code-of-conduct@googlegroups.com. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org


### PR DESCRIPTION
With this commit we'll have the basic docs that are required for all
Tekton projects
(https://github.com/tektoncd/community/blob/master/process.md#project-requirements)
and a start at development + contributing guides, hopefully enough to
meet the requirements for #2 though we could still flesh these out
further.

Fixes #2