### PR TITLE
Transform markdown links to hugo style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ public/
 package-lock.json
 node_modules/
 assets/js/version-switcher.js
+content/en/docs/Pipelines/
+content/en/docs/Triggers/


### PR DESCRIPTION
Fixes #37 
(Still needs us to update the doc for Pipeline and Triggers to include front matter headers in comment)
# Changes
Adds a "transform_links" function to sync.py so that "relative" *.md links are transformed into the format hugo expects.

Also add .gitignore entries for the Pipeline and Trigger content.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
