### PR TITLE
Changed some v1alpha1 in Getting Started

### DIFF
--- a/content/en/docs/Getting Started/_index.md
+++ b/content/en/docs/Getting Started/_index.md
@@ -300,7 +300,7 @@ step, printing a `Hello World!` message using
 [the official Ubuntu image](https://hub.docker.com/_/ubuntu/):
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: echo
@@ -324,7 +324,7 @@ To run this task with Tekton, you need to create a **taskRun**, which is
 another Kubernetes object using the Tekton API:
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
   name: getting-started


### PR DESCRIPTION
Found two more instances of 
apiVersion: v1alpha1
in the Getting Started page. Updated those to use
apiVersion: v1beta1

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In the Getting Started page, there were two more references to v1alpha1. Changed both.  Those are the only ones I could find.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
