### PR TITLE
fix the link of github and qwiklabs

### DIFF
--- a/assets/js/launch-tutorial.js
+++ b/assets/js/launch-tutorial.js
@@ -15,8 +15,8 @@ function getKatacodaLnk (katacodaSrc) {
 function openModal (article) {
   const katacodaSrc = article.attr('data-katacoda-src');
   const katacodaLnk = getKatacodaLnk(katacodaSrc);
-  const githubLnk = article.attr('data-github-src');
-  const qwiklabsLnk = article.attr('data-qwiklabs-src');
+  const githubLnk = article.attr('data-github-lnk');
+  const qwiklabsLnk = article.attr('data-qwiklabs-lnk');
 
   $('#katacoda-button').attr('href', `https://katacoda.com/${katacodaLnk}`);
   $('#github-button').attr('href', `https://github.com/${githubLnk}`);


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The github link of Interactive Tutorial is https://github.com/undefined. 
It is incorrect. 
So does the qwiklabs link. 
Then fix them.

reference: [layouts/shortcodes/tutorial.html](https://github.com/tektoncd/website/blob/master/layouts/shortcodes/tutorial.html)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
