### PR TITLE
Include tkn start in Getting Started Section and Remove Need to Save TaskRun to Local File

### DIFF
--- a/content/en/docs/Getting Started/_index.md
+++ b/content/en/docs/Getting Started/_index.md
@@ -302,15 +302,15 @@ sudo tar xvzf YOUR-DOWNLOADED-FILE -C /usr/local/bin/ tkn
 
 ## Your first CI/CD workflow with Tekton
 
-With Tekton, each operation in your CI/CD workflow becomes a **step**,
-which is executed with a container image you specify. **Steps** are then
-organized in **tasks**, which run as a [Kubernetes pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/)
-in your cluster. If you would like to, you can further organize **tasks**
-into **pipelines**.
+With Tekton, each operation in your CI/CD workflow becomes a `Step`,
+which is executed with a container image you specify. `Steps` are then
+organized in `Tasks`, which run as a [Kubernetes pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/)
+in your cluster. You can further organize `Tasks` into `Pipelines`, which 
+can control the order of execution of several `Tasks`. 
 
-To create a **task**, create a Kubernetes object using the Tekton API with
-the kind `Task`. The following YAML file specifies a task with one simple
-step, printing a `Hello World!` message using
+To create a `Task`, create a Kubernetes object using the Tekton API with
+the kind `Task`. The following YAML file specifies a `Task` with one simple
+`Step`, which prints a `Hello World!` message using
 [the official Ubuntu image](https://hub.docker.com/_/ubuntu/):
 
 ```yaml
@@ -328,14 +328,22 @@ spec:
         - "Hello World!"
 ```
 
-Write this file to `task.yaml`, and apply it to your Kubernetes cluster:
+Write the YAML above to a file named `task.yaml`, and apply it to your Kubernetes cluster:
 
 ```
 kubectl apply -f task.yaml
 ```
 
-To run this task with Tekton, you need to create a **taskRun**, which is
-another Kubernetes object using the Tekton API:
+To run this task with Tekton, you need to create a `TaskRun`, which is
+another Kubernetes object used to specify run time information for a `Task`. 
+
+To view this `TaskRun` object you can run the following Tekton CLI (`tkn`) command:
+
+```shell
+tkn task start echo --dry-run
+```
+
+After running the command above, the following `TaskRun` definition should be shown:
 
 ```yaml
 apiVersion: tekton.dev/v1beta1
@@ -347,21 +355,33 @@ spec:
     name: echo
 ```
 
-Write this file to `taskRun.yaml`, and apply it to your Kubernetes cluster:
+To use the `TaskRun` above to start the `echo` `Task`, you can either use 
+`tkn` or `kubectl`.
 
-```bash
+Start with `tkn`:
+
+```shell
+tkn task start echo
+```
+
+Start with `kubectl`:
+
+```shell
+# use tkn's --dry-run option to save the TaskRun to a file
+tkn task start echo --dry-run > taskRun.yaml
+# apply the TaskRun
 kubectl apply -f taskRun.yaml
 ```
 
-Tekton will now start running your task. To check out the output, run the
-command below:
+Tekton will now start running your `Task`. To see the logs of the `TaskRun`, run 
+the following `tkn` command:
 
-```bash
-tkn taskrun logs getting-started
+```shell
+tkn taskrun logs getting-started -f
 ```
 
-It may take a few moments before your task completes. You should see an output
-as follows:
+It may take a few moments before your `Task` completes. When it executes, it should 
+show the following output:
 
 ```
 [echo] Hello World!
@@ -370,7 +390,7 @@ as follows:
 ## What's next
 
 Now you have the core component of Tekton, Tekton Pipelines, installed on
-your Kubernetes/OpenShift cluster with the Tekton CLI installed on your local
+your Kubernetes or OpenShift cluster with the Tekton CLI installed on your local
 machine. If you would like to install more components, see the list below:
 
 * [Tekton Triggers](/docs/triggers)


### PR DESCRIPTION
This pull request adds more information on using `tkn` to start a `TaskRun` as opposed to making the user save a `TaskRun` ofd the website to a local file to start a `Task`. 

It would also be helpful to include a way for the user to not have to save the `Task` definition locally either to make it simpler to go through the tutorial (i.e. create the `Task` from a remote file using `kubectl apply -f`. Perhaps the `Task` definition can be stored in the website repo the link to it can be included in the documentation.

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
