### PR TITLE
Add missing YAML files to Triggers sync config

### DIFF
--- a/sync/config/triggers.yaml
+++ b/sync/config/triggers.yaml
@@ -33,5 +33,7 @@ tags:
   - triggertemplates.md: triggertemplates.md
   - clustertriggerbindings.md: clustertriggerbindings.md
   - cel_expressions.md: cel_expressions.md
+  - create-ingress.yaml: create-ingress.yaml
+  - create-webhook.yaml: create-webhook.yaml
 # The link to the GitHub tag page.
 archive: https://github.com/tektoncd/triggers/tags


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/website/issues/81

The samples for the two 'Getting Started' links at the end of the main
Triggers page in the docs are missing so the links result in 404.

Add the YAML files to the sync config so they'll be included and available
from the links on the website.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
