### PR TITLE
Added a function called is_http to prevent url mangling

### DIFF
--- a/sync/sync.py
+++ b/sync/sync.py
@@ -32,9 +32,14 @@ def transform_links(link_prefix, dest_prefix, files):
         for k in f:
             dest_path = f'{dest_prefix}/{f[k]}'
             for line in fileinput.input(dest_path, inplace=1):
-                line = re.sub(RELATIVE_LINKS_RE, r'[\1](' + link_prefix + r'\2\3)', line.rstrip())
+                if not is_http(line):
+                    line = re.sub(RELATIVE_LINKS_RE, r'[\1](' + link_prefix + r'\2\3)', line.rstrip())
                 print(line)
 
+def is_http(str):
+    if "http://" or "https://":
+        return True
+    return False
 
 def retrieve_files(url_prefix, dest_prefix, files):
     if os.path.isdir(dest_prefix):


### PR DESCRIPTION
The transform link changes the link for keywords regardless if its an abs reference or local. This function ensure that links that are suppose to be local become transformed

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
