### PR TITLE
[WIP] Removed edit this page on right-side navbar.

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -33,8 +33,6 @@ other = "By"
 other = "Created"
 [post_last_mod]
 other = "Last modified"
-[post_edit_this]
-other = "Edit this page"
 [post_create_issue]
 other = "Create documentation issue"
 [post_create_project_issue]

--- a/themes/docsy/layouts/partials/page-meta-links.html
+++ b/themes/docsy/layouts/partials/page-meta-links.html
@@ -13,7 +13,6 @@
 {{ $editURL = printf "%s/edit/master/%s/content/%s" $gh_repo $gh_subdir $.Path }}
 {{ end }}
 {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
-<a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
 <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
 {{ if $gh_project_repo }}
 {{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}


### PR DESCRIPTION
This commit is a fix for [issue 65](https://github.com/tektoncd/website/issues/65). The right side-navbar had a link to github to edit the page. However, the reference was to the webiste. The website does not hold any documentation. This is confusing for the user. Since, editing the index will be ignored and some docs are missing on the website repo because the source of truth is the project repo. Removing the link is a temporary solution to fix broken links. The link was removed because it confuses the user.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
