### PR TITLE
Change styling for privacy-notice

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -8,9 +8,11 @@ $td-fonts-serif: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxyge
 $td-enable-google-fonts: false;
 $light: #929292 !default;
 $dark: #333 !default;
+$mobile-width: 767px;
 
 /*
     Styling for privacy notice watermark
+    in privacy-notice.html
 */
 #privacy-notice {
     background-color: rgba(84, 73, 75, 0.9); 
@@ -25,8 +27,20 @@ $dark: #333 !default;
 }
 
 
-@media only screen and (max-width: 500px) {
+@media only screen and (max-width: $mobile-width) {
     #privacy-notice {
         width: 100vw;
     }
+    
+}
+
+/* 
+    Styling for banner at banner-hero-logo:
+    Logo is not responsive and breaks the flow of the website.
+*/
+@media only screen and (max-width: $mobile-width) {
+    #banner-hero-logo {
+        display: none
+    }
+    
 }

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -8,3 +8,25 @@ $td-fonts-serif: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxyge
 $td-enable-google-fonts: false;
 $light: #929292 !default;
 $dark: #333 !default;
+
+/*
+    Styling for privacy notice watermark
+*/
+#privacy-notice {
+    background-color: rgba(84, 73, 75, 0.9); 
+    position: fixed; 
+    top: 100%; 
+    right: 0%; 
+    width: 500px; 
+    margin: -15rem 0 0 0; 
+    height: 15rem;
+    box-shadow: -8px -8px 8px 0 rgba(0, 0, 0, 0.3), 2px -6px 20px 0 rgba(0, 0, 0, 0.2); 
+    z-index: 1;
+}
+
+
+@media only screen and (max-width: 500px) {
+    #privacy-notice {
+        width: 100vw;
+    }
+}

--- a/layouts/partials/privacy-notice.html
+++ b/layouts/partials/privacy-notice.html
@@ -1,4 +1,4 @@
-<div id="privacy-notice" style="background-color: rgba(84, 73, 75, 0.9); position: fixed; bottom: 40px; right: 0%; width: 60%; min-height: 160px; box-shadow: -8px -8px 8px 0 rgba(0, 0, 0, 0.3), 2px -6px 20px 0 rgba(0, 0, 0, 0.2);">
+<div id="privacy-notice">
     <div class="row ml-4 mt-3 mb-3">
       <div class="col-11">
         <p class="h5 text-white">This website uses cookies</p>

--- a/layouts/shortcodes/blocks/cover.html
+++ b/layouts/shortcodes/blocks/cover.html
@@ -25,7 +25,7 @@
 {{ end }}
 <section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height }} js-td-cover td-overlay td-overlay--dark -bg-{{ $col_id }}">
   <div class="container td-overlay__inner">
-    <img class="hero-logo" src="images/tekton-horizontal-color.png">
+    <img id="banner-hero-logo" class="hero-logo" src="images/tekton-horizontal-color.png">
     <div class="row">
       <div class="col-6">
         <div class="text-left">


### PR DESCRIPTION
Privacy notice banner was offset and was not visible when site was docked to partial view. This allows a user to view the privacy notice properly.

Before:
<img width="1680" alt="Screen Shot 2020-05-06 at 1 03 03 PM" src="https://user-images.githubusercontent.com/1755197/81212042-46970e00-8fa2-11ea-98e8-72eb1ea8202a.png">

After:
<img width="1680" alt="Screen Shot 2020-05-06 at 1 03 42 PM" src="https://user-images.githubusercontent.com/1755197/81212075-531b6680-8fa2-11ea-9dc2-796972847559.png">

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
