### PR TITLE
Allow contributors to cherry pick docs in config for sync

### DIFF
--- a/sync/config/pipelines.yaml
+++ b/sync/config/pipelines.yaml
@@ -26,6 +26,7 @@ tags:
   # and the value is the new filename.
   files:
   - README.md: _index.md
+    commit: 0d9818d2686a9acad126e332d6317eec18a06bc4
   - auth.md: auth.md
   - conditions.md: conditions.md
   - container-contract.md: container-contract.md
@@ -38,7 +39,7 @@ tags:
   - resources.md: resources.md
   - taskruns.md: taskruns.md
   - tasks.md: tasks.md
-  - workspaces.md: workspaces.md
+  - workspaces.md: workspaces.md    
 # To add a new version, append to the list as below
 #- name: v0.8.2
 #  displayName: v0.8.x

--- a/sync/sync.py
+++ b/sync/sync.py
@@ -42,7 +42,14 @@ def retrieve_files(url_prefix, dest_prefix, files):
     os.mkdir(dest_prefix)
     for f in files:
         for k in f:
-            src_url = f'{url_prefix}/{k}'
+            if "commit" == k:
+                continue;
+
+            if "commit" in f:
+                url = url_prefix.replace('master', f["commit"])
+                src_url = f'{url}/{k}'
+            else:
+                src_url = f'{url_prefix}/{k}'
             dest_path = f'{dest_prefix}/{f[k]}'
             print(f'Downloading file (from {src_url} to {dest_path}).\n')
             os.makedirs(os.path.dirname(dest_path), exist_ok=True)
@@ -70,6 +77,7 @@ def sync(sync_config):
     files = tags[0]['files']
     print(f'Retrieving the latest version ({tags[0]["displayName"]}) of Tekton {component} documentation (from {url_prefix} to {dest_prefix}).\n')
     retrieve_files(url_prefix, dest_prefix, files)
+    entries_to_remove("commit", files)
     transform_links(f'/docs/{component.lower()}/', dest_prefix, files)
 
     # Get the previous versions of contents
@@ -81,6 +89,10 @@ def sync(sync_config):
         retrieve_files(url_prefix, dest_prefix, files)
         transform_links(f'/vault/{component.lower()}-{tag["displayName"]}/', dest_prefix, files)
 
+def entries_to_remove(entry, files):
+    for f in files:
+        if entry in f:
+            del f[entry]
 
 def get_component_versions(sync_configs):
     component_versions = []


### PR DESCRIPTION
Fix for [#108](https://github.com/tektoncd/website/issues/108). There is not a way to patch docs if there an issue since it is based on the tag. This change to the script lets you cherry pick docs under a commit within its respective repo. This allows for greater flexibility when synchronizing the docs.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

You can now add a commit field to the config yaml. This will force the reademe to pulled from that commit.

```yaml
component: Pipelines
displayOrder: 0
repository: https://github.com/tektoncd/pipeline
docDirectory: docs
tags:
- name: master
  displayName: master
  files:
  - README.md: _index.md
    commit: 0d9818d2686a9acad126e332d6317eec18a06bc4
  - auth.md: auth.md
  - conditions.md: conditions.md
archive: https://github.com/tektoncd/pipeline/tags


```


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
