### PR TITLE
Update 'Edit this page' link to point to correct project repo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -74,7 +74,7 @@ weight = 1
 version_menu = "Releases"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/tektoncd/website/"
+github_repo = "https://github.com/tektoncd/website"
 
 # Specify a value here if your content directory is not in your repo's root directory
 # github_subdir = ""

--- a/themes/docsy/layouts/partials/page-meta-links.html
+++ b/themes/docsy/layouts/partials/page-meta-links.html
@@ -5,20 +5,22 @@
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
 {{ $editURL := printf "%s/edit/master/content/%s" $gh_repo .Path }}
-{{ if and ($gh_subdir) (.Site.Language.Lang) }}
+{{ if $gh_project_repo }}
+{{ $filename := .File.LogicalName }}
+{{ if and $gh_project_repo (eq $filename "_index.md") }}
+{{ $filename = "README.md" }}
+{{ end }}
+{{ $editURL = printf "%s/edit/master/docs/%s" $gh_project_repo $filename }}
+{{ else if and ($gh_subdir) (.Site.Language.Lang) }}
 {{ $editURL = printf "%s/edit/master/%s/content/%s/%s" $gh_repo $gh_subdir ($.Site.Language.Lang) $.Path }}
 {{ else if .Site.Language.Lang }}
 {{ $editURL = printf "%s/edit/master/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
 {{ else if $gh_subdir }}
 {{ $editURL = printf "%s/edit/master/%s/content/%s" $gh_repo $gh_subdir $.Path }}
 {{ end }}
-{{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
+{{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape ($.Title | default $.LinkTitle ))}}
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
 <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
-{{ if $gh_project_repo }}
-{{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
-<a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
-{{ end }}
 </div>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/website/issues/65

It's possible to define page-level params in each project repo that cascade to all child pages. We could use this to make project-specific config available in our templates without having to duplicate it on each page.

For example, taking the Triggers project, adding something like this to the README.me (renamed to _index.md on the website):

```diff
---
title: "Triggers"
linkTitle: "Triggers"
weight: 4
description: >
  Event Triggers
+cascade:
+  github_project_repo: https://github.com/tektoncd/triggers
---
```

This allows us to point the 'Edit this page' and 'Create documentation issue' links to the correct location. If this `github_project_repo` param is not present, it falls back to existing behaviour so that content from the website repo itself is still linked correctly.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
