### PR TITLE
Remove sbwsg from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,5 +9,7 @@ approvers:
 - lucperkins
 - afrittoli
 - skaegi
-- sbwsg
 - AlanGreene
+
+# Alumni ❤️
+# sbwsg


### PR DESCRIPTION
# Changes

This PR removes me from OWNERS file.

It made sense for me to be in OWNERS while we were releasing Beta but I'm not keeping up with current website planning & work so don't want to be blocking reviews.