### PR TITLE
add --dry-run option to command

### DIFF
--- a/content/en/docs/Getting Started/_index.md
+++ b/content/en/docs/Getting Started/_index.md
@@ -140,7 +140,8 @@ the `manual` storage class when running a workflow:
 kubectl create configmap config-artifact-pvc \
                          --from-literal=size=10Gi \
                          --from-literal=storageClassName=manual \
-                         -o yaml -n tekton-pipelines | kubectl replace -f -
+                         -o yaml -n tekton-pipelines \
+                         --dry-run=client | kubectl replace -f -
 ```
 {{% /tab %}}
 
@@ -168,7 +169,8 @@ kubectl create configmap config-artifact-pvc \
                          --from-literal=location=gs://MY-GCS-BUCKET \
                          --from-literal=bucket.service.account.secret.name=my-secret \
                          --from-literal=bucket.service.account.secret.key=my-key \
-                         -o yaml -n tekton-pipelines | kubectl replace -f -
+                         -o yaml -n tekton-pipelines \
+                         --dry-run=client | kubectl replace -f -
 ```
 
 And the `my-secret` Kubernetes secret is configured as follows:
@@ -193,7 +195,8 @@ update the `default-service-account` attribute of the `ConfigMap`
 ```
 kubectl create configmap config-defaults \
                          --from-literal=default-service-account=YOUR-SERVICE-ACCOUNT \
-                         -o yaml -n tekton-pipelines | kubectl replace -f -
+                         -o yaml -n tekton-pipelines \
+                         --dry-run=client  | kubectl replace -f -
 ```
 
 ### Set up the CLI


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

With tekton pipeline installed, cm `config-artifact-pvc` (and more) is created automatically. Running below command to will fail with `Error from server (AlreadyExists): configmaps "config-artifact-pvc" already exists`.

```
kubectl create configmap config-artifact-pvc \
                         --from-literal=size=10Gi \
                         --from-literal=storageClassName=manual \
                         -o yaml -n tekton-pipelines | kubectl replace -f -
```

With `--dry-run=client`, it works.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
