### PR TITLE
Add steps to docs for running website dev envrioment locally

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,47 +1,40 @@
 # Developing the Tekton website
 
 - [Developing the Tekton website](#developing-the-tekton-website)
-  - [Running Locally](#running-locally)
-  - [tekton.dev](#tektondev)
+- [Running Locally](#running-locally)
+- [tekton.dev](#tektondev)
+
+## Dependencies
+
+* [python3](https://www.python.org/downloads/) 
+* [hugo (EXTENDED VERSION)](https://github.com/gohugoio/hugo/releases)
+* [pip](https://pip.pypa.io/en/stable/installing/)
+* [npm v6.14.5](https://nodejs.org/en/)
+* [node v14.3.0](https://nodejs.org/en/)
+* [netlify cli](https://cli.netlify.com/getting-started)
+* [netlify account](https://app.netlify.com/)
 
 ## Running Locally
 
-
-The [tekton.dev](#tekton.dev) is deployed on Netlify. Netlify will invoke
-[the Makefile](.Makefile) to build the website.
-
-This is configured in:
-
-* [netlify.toml](netlify.toml)
-* [runtime.txt](runtime.txt) (the python runtime)
-* [requirements.txt](requirements.txt) (the python requirements)
-
-To run it locally you will need to install:
-
-* [Hugo](https://gohugo.io/) [version 0.53](netlify.toml)
-* `npm` to install Hugo's requirements:
-  * `npm install` (in directory with [package.json](package.json))
-
-Then you can run [hugo commands](https://gohugo.io/getting-started/usage/) such as:
-
+Step 1
 ```bash
-hugo server
+git clone https://github.com/tektoncd/website && cd website
 ```
-
-To run the [Makefile](Makefile) you will need more dependencies and flags:
-
-* `python` aliased to python3.7 - [sync.py](sync/sync.py) is running `python` but assumes this is python3 (configured in [runtime.txt](runtime.txt))
-* `pip`, to install python requirements:
-  * Install with `pip install -r requirements.txt`
-
-To run the makefile locally, you'll have to set the env var:
-
-* [`DEPLOY_PRIME_URL`](https://docs.netlify.com/configure-builds/environment-variables/) to the path to your website files
-
-For example:
-
+Step 2
 ```bash
-DEPLOY_PRIME_URL=localhost make preview-build
+npm install
+```
+Step 3
+```bash
+pip install -r requirements.txt
+```
+Step 4
+```bash
+python3 sync/sync.py
+```
+Step 5
+```bash
+netlify dev
 ```
 
 ## tekton.dev

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: sync
 sync:
-	python sync/sync.py
+	python3 sync/sync.py
 
 .PHONY: serve
 serve:


### PR DESCRIPTION
It is not straight forward on how to run the dev environment. You can not run the website locally without running npm, the sync script and hugo in a specific order. I do not believe this is documentation anywhere and was mention in this issue. https://github.com/tektoncd/website/issues/3

# Changes

I added instructions on to run the tekton website dev environment.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
