### PR TITLE
Fixing the getting-started in triggers

### DIFF
--- a/sync/config/triggers.yaml
+++ b/sync/config/triggers.yaml
@@ -35,5 +35,6 @@ tags:
   - cel_expressions.md: cel_expressions.md
   - getting-started/create-ingress.yaml: create-ingress.yaml
   - getting-started/create-webhook.yaml: create-webhook.yaml
+  - create-ingress.yaml: create-ingress.yaml
 # The link to the GitHub tag page.
 archive: https://github.com/tektoncd/triggers/tags


### PR DESCRIPTION
I believe this will bring the getting-started/_index.md to the correct
place fixing the link.

Signed-off-by: JJ Asghar <jjasghar@gmail.com>