### PR TITLE
Change "kubernetes native" to "cloud native" ☁️

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -57,7 +57,7 @@ id = "UA-154682132-1"
 [languages]
 [languages.en]
 title = "Tekton"
-description = "Kubernetes-native CI/CD"
+description = "Cloud Native CI/CD"
 languageName ="English"
 # Weight used for sorting.
 weight = 1

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -4,7 +4,7 @@ linkTitle = "Tekton.dev Homepage"
 
 +++
 
-{{< blocks/cover title="Kubernetes-native CI/CD" subtitle="" image_anchor="smart" color="orange" height="med">}}
+{{< blocks/cover title="Cloud Native CI/CD" subtitle="" image_anchor="smart" color="orange" height="med">}}
 <div class="mx-auto">
 	<a class="btn btn-lg btn-dark mr-3 mb-4" href="{{< relref "/docs" >}}">
 		Documentation <i class="fas fa-arrow-alt-circle-right ml-2"></i>

--- a/content/en/docs/Concepts/_index.md
+++ b/content/en/docs/Concepts/_index.md
@@ -12,7 +12,7 @@ This document is a work in progress.
 
 ## Overview
 
-Tekton is an open-source Kubernetes native CI/CD (Continuous Integration and
+Tekton is an open-source cloud native CI/CD (Continuous Integration and
 Delivery/Deployment) solution. It allows developers to build, test, and
 deploy across destinations using a Kubernetes cluster of their own.
 

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -8,7 +8,7 @@ menu:
     weight: 20
 ---
 
-Tekton is a Kubernetes-native continuous integration and delivery (CI/CD)
+Tekton is a cloud native continuous integration and delivery (CI/CD)
 solution. It allows developers to build, test, and deploy across cloud
 providers and on-premise systems.
 


### PR DESCRIPTION
# Changes

Tekton is a cloud native project, not necessarily a kubernetes native
project, and in fact (beyond basing our design around k8s style
resources and using k8s containers) we try to minimize our coupling to
k8s (at least in our API).

If you look at our README you can see that we are k8s-style and cloud
native: https://github.com/tektoncd/pipeline#-tekton-pipelines

You can see this reflected in our mission as well:
"Be the industry-standard, cloud-native CI/CD platform components and
ecosystem."
https://github.com/tektoncd/community/blob/master/roadmap.md#mission-and-vision

This commit updates the wording to be a bit more accurate.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
