### PR TITLE
Fix path to Triggers yaml files in sync config

### DIFF
--- a/sync/config/triggers.yaml
+++ b/sync/config/triggers.yaml
@@ -33,7 +33,7 @@ tags:
   - triggertemplates.md: triggertemplates.md
   - clustertriggerbindings.md: clustertriggerbindings.md
   - cel_expressions.md: cel_expressions.md
-  - create-ingress.yaml: create-ingress.yaml
-  - create-webhook.yaml: create-webhook.yaml
+  - getting-started/create-ingress.yaml: create-ingress.yaml
+  - getting-started/create-webhook.yaml: create-webhook.yaml
 # The link to the GitHub tag page.
 archive: https://github.com/tektoncd/triggers/tags


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Some of the Triggers content was moved in https://github.com/tektoncd/triggers/pull/642,
specifically: create-ingress.yaml and create-webhook.yaml

These have been moved to the getting-started folder which broke
the website sync script, blocking other changes. This can be seen
in the failing `netlify/tekton/deploy-preview` check on PRs.

Update the sync config to point to the new paths to unblock
other changes.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
