### PR TITLE
Add Katacoda playground

### DIFF
--- a/tutorials/katacoda/playground/assets/wait.sh
+++ b/tutorials/katacoda/playground/assets/wait.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+waitForCompletion() {
+  local -r delay='0.75'
+  local spinstr='\|/-'
+  local temp
+  while true; do
+    sudo grep -i "done" $1 &> /dev/null
+    if [[ "$?" -ne 0 ]]; then
+      temp="${spinstr#?}"
+      printf " [%c]  " "${spinstr}"
+      spinstr=${temp}${spinstr%"${temp}"}
+      sleep "${delay}"
+      printf "\b\b\b\b\b\b"
+    else
+      break
+    fi
+  done
+  printf "    \b\b\b\b"
+  echo ""
+}
+
+showProgress()
+{
+  echo -n "Starting cluster"
+  waitForCompletion /opt/.clusterstarted
+  echo -n "Installing Tekton Pipelines"
+  waitForCompletion /opt/.pipelinesinstalled
+  echo -n "Installing Tekton Dashboard"
+  waitForCompletion /opt/.dashboardinstalled
+  echo -n "Installing Tekton CLI"
+  waitForCompletion /opt/.tkninstalled
+  echo -n "Waiting for pods to be ready"
+  waitForCompletion /opt/.podsready
+  echo -n "Configuring ingress"
+  waitForCompletion /opt/.ingressconfigured
+  # echo -n "Completing"
+  # waitForCompletion /opt/.backgroundfinished
+  echo "Ready"
+  echo ""
+}
+
+showProgress

--- a/tutorials/katacoda/playground/background.sh
+++ b/tutorials/katacoda/playground/background.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Start Kubernetes
+echo "Starting cluster"
+launch.sh
+echo "done" >> /opt/.clusterstarted
+
+echo "Installing Tekton Pipelines"
+kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.14.3/release.yaml
+
+mkdir /mnt/data
+
+kubectl apply -f - << EOF
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: task-pv-volume
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"
+EOF
+
+kubectl delete configmap/config-artifact-pvc -n tekton-pipelines
+kubectl create configmap config-artifact-pvc --from-literal=storageClassName=manual -n tekton-pipelines
+
+echo "done" >> /opt/.pipelinesinstalled
+
+echo "Installing Tekton Dashboard"
+kubectl apply --filename https://github.com/tektoncd/dashboard/releases/download/v0.8.2/tekton-dashboard-release.yaml
+echo "done" >> /opt/.dashboardinstalled
+
+echo "Installing Tekton CLI"
+curl -LO https://github.com/tektoncd/cli/releases/download/v0.11.0/tkn_0.11.0_Linux_x86_64.tar.gz
+tar xvzf tkn_0.11.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
+echo "done" >> /opt/.tkninstalled
+
+echo "Waiting for Tekton pods to be ready"
+# Need to wait for pods to be scheduled first otherwise `kubectl wait` exits immediately with error
+while [[ $(kubectl get pods -n tekton-pipelines --no-headers | wc -l) != 3 ]]; do echo "waiting" && sleep 1; done
+kubectl wait pod -n tekton-pipelines --all --for=condition=Ready --timeout=180s
+echo "done" >> /opt/.podsready
+
+echo "Configure ingress"
+kubectl --namespace tekton-pipelines port-forward --address=0.0.0.0 service/tekton-dashboard 9097:9097 &
+echo "done" >> /opt/.ingressconfigured
+
+echo "done" >> /opt/.backgroundfinished

--- a/tutorials/katacoda/playground/finish.md
+++ b/tutorials/katacoda/playground/finish.md
@@ -1,0 +1,5 @@
+## Congratulations
+
+If you would like to learn more about Tekton, visit [tekton.dev](https://tekton.dev).
+
+For more Tekton interactive tutorials, see [tekton.dev/try](https://tekton.dev/try).

--- a/tutorials/katacoda/playground/foreground.sh
+++ b/tutorials/katacoda/playground/foreground.sh
@@ -1,0 +1,1 @@
+sleep 3; wait.sh

--- a/tutorials/katacoda/playground/index.json
+++ b/tutorials/katacoda/playground/index.json
@@ -1,0 +1,47 @@
+{
+  "title": "Tekton Playground",
+  "description": "Experiment, explore, and learn Tekton",
+  "difficulty": "Beginner",
+  "time": "10 minutes",
+  "details": {
+    "steps": [
+      {
+        "background": "background.sh",
+        "foreground": "foreground.sh",
+        "text": "step1.md"
+      }
+    ],
+    "intro": {
+      "text": "intro.md"
+    },
+    "finish": {
+      "text": "finish.md"
+    },
+    "assets": {
+      "host01": [
+        {
+          "file": "wait.sh",
+          "target": "/usr/local/bin/",
+          "chmod": "+x"
+        }
+      ]
+    }
+  },
+  "environment": {
+    "showdashboard": true,
+    "uilayout": "terminal-iframe",
+    "uimessage1": "\u001b[32mSetting up your Tekton playground...\u001b[m\r\n",
+    "hideintro": false,
+    "hidefinish": false,
+    "dashboards": [
+      {
+        "name": "Dashboard",
+        "port": 9097
+      }
+    ]
+  },
+  "backend": {
+    "imageid": "kubernetes-cluster-running:1.18",
+    "port": "80"
+  }
+}

--- a/tutorials/katacoda/playground/intro.md
+++ b/tutorials/katacoda/playground/intro.md
@@ -1,0 +1,11 @@
+[Tekton](https://tekton.dev) is a cloud native continuous integration and delivery (CI/CD) solution. It allows developers to build, test, and deploy across cloud providers and on-premises systems.
+
+This playground features a pre-configured Kubernetes cluster with two nodes, one configured as the Control Plane node and a second worker node. It also comes with Tekton installed, so that you can experiment, explore, and learn about Tekton as you see fit. The following components are available:
+
+- Tekton Pipelines
+- Tekton Dashboard
+- Tekton CLI
+
+Additionally, the Kubernetes cluster includes:
+
+- A PersistentVolume for [artifact storage](https://github.com/tektoncd/pipeline/blob/v0.13.2/docs/install.md#configuring-artifact-storage)

--- a/tutorials/katacoda/playground/step1.md
+++ b/tutorials/katacoda/playground/step1.md
@@ -1,0 +1,19 @@
+#### Try it out
+
+Please wait while your Tekton playground is starting, this may take a few minutes.
+
+Once it is ready you can check the installed versions:
+`tkn version`{{execute}}
+
+Try out some of the [examples](https://github.com/tektoncd/pipeline/tree/master/examples) from the Tekton Pipeline repo.
+
+For example:
+`kubectl apply -f https://raw.githubusercontent.com/tektoncd/pipeline/master/examples/v1beta1/pipelineruns/output-pipelinerun.yaml`{{execute}}
+
+You can track the progress of the `PipelineRuns` using:
+
+`kubectl get pipelineruns`{{execute}}
+
+`tkn pipelinerun list`{{execute}}
+
+or check out the Tekton Dashboard at http://[[HOST_SUBDOMAIN]]-9097-[[KATACODA_HOST]].environments.katacoda.com/


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Add a Katacoda scenario that can act as a playground for users
to experiment with Tekton in a sandbox environment.

This environment provides a 2-node Kubernetes cluster with the
following projects installed:
- Pipelines v0.14.3
- Dashboard v0.8.2
- CLI v0.11.0

Typical startup time is <1minute, but may take 2 or 3 minutes
in some cases. The installation should not require any manual
steps by the user.

I currently have this deployed at https://katacoda.com/alangreene-tektoncd/scenarios/playground for testing.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
