### PR TITLE
Add missing metadata.name for TaskRun doc

### DIFF
--- a/content/en/docs/Getting Started/_index.md
+++ b/content/en/docs/Getting Started/_index.md
@@ -352,6 +352,7 @@ After running the command above, the following `TaskRun` definition should be sh
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
+  name: hello-run
   generateName: hello-run-
 spec:
   taskRef:

--- a/tutorials/katacoda/basic-pipeline/step1.md
+++ b/tutorials/katacoda/basic-pipeline/step1.md
@@ -40,6 +40,7 @@ After running the command above, the following TaskRun definition should be show
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
+  name: hello-run
   generateName: hello-run-
 spec:
   taskRef:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

As title, I've added `metadata.name` for `kind: TaskRun` examples.

When I applied the current example, the server returned error.

```
error: error when retrieving current configuration of:
Resource: "tekton.dev/v1beta1, Resource=taskruns", GroupVersionKind: "tekton.dev/v1beta1, Kind=TaskRun"
Name: "", Namespace: "tekton-pipelines"
from server for: "manifest/taskrun/hello.yml": resource name may not be empty
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
