### PR TITLE
Change from releases to versions

### DIFF
--- a/layouts/partials/navbar-version-selector-docs.html
+++ b/layouts/partials/navbar-version-selector-docs.html
@@ -3,16 +3,16 @@
 <script src="{{ $jsVerSwitcher.RelPermalink }}" integrity="{{ $jsVerSwitcher.Data.Integrity }}"></script>
 <li class="nav-item dropdown d-none d-lg-block">
     <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Latest Releases
+        Latest Versions
     </a>
     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownMenuLink">
         <div class="dropdown-item disabled">
             <p class="mb-0">You are viewing the documentation of the</p>
-            <p class="mb-0">lastest releases of Tekton components.</p>
+            <p class="mb-0">lastest versions of Tekton components.</p>
         </div>
         <form id="version-announcer"></form>
         <div class="dropdown-divider"></div>
-        <h6 class="dropdown-header">Previous Releases</h6>
+        <h6 class="dropdown-header">Other Versions</h6>
         <form id="previous-releases-form"></form>
     </div>
 </li>

--- a/templates/version-switcher.js.template
+++ b/templates/version-switcher.js.template
@@ -30,7 +30,7 @@ function createArchivedVersionsNode (anchorNode, componentName, href) {
   archiveNode.style.paddingLeft = '2em';
   archiveNode.style.color = 'rgb(55, 114, 255)';
   archiveNode.setAttribute('data-ref', `${componentName}-child`.toLowerCase());
-  archiveNode.innerHTML = 'Archived Versions';
+  archiveNode.innerHTML = 'Releases on GitHub';
   archiveNode.setAttribute('href', href);
   anchorNode.appendChild(archiveNode);
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The version switcher dropdown box mentiones releases, however currently
it refers to "master" which is not a release at all. I think we could
use the wording "version" which is more generic.

Archived versions instead is a link to releases on github. Changing the
wording accordingly.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
