### PR TITLE
Use a trailing slash for the rewrite URL

### DIFF
--- a/sync/sync.py
+++ b/sync/sync.py
@@ -99,7 +99,6 @@ def transform_link(link, base_path, rewrite_path, rewrite_url):
     Note that urlparse treats URLs without scheme like path only
     URLs, so 'github.com' will be rewritten to base_url/github.com
     """
-
     # ignore empty links
     if not link:
         return link
@@ -179,7 +178,7 @@ def download_resources_to_project(yaml_list):
         for index, tag in enumerate(entry['tags']):
             logging.info(f'Syncing {component}@{tag["name"]}')
             download_url = f'{repository}/raw/{tag["name"]}/{doc_directory}'
-            link_base_url = f'{repository}/tree/{tag["name"]}/{doc_directory}'
+            link_base_url = f'{repository}/tree/{tag["name"]}/{doc_directory}/'
             if index == 0:
                 # first links belongs on the home page
                 download_dir = f'/docs/{component}'.lower()

--- a/sync/test_sync.py
+++ b/sync/test_sync.py
@@ -191,9 +191,10 @@ class TestSync(unittest.TestCase):
             "[exists-relative-link](test-content/test.txt)\n"
             "[exists-relative-link](test-content/content/)\n"
             "[exists-relative-link-fragment](test-content/test.txt#fragment)\n"
-            "[notfound-relative-link](http://test.com/this/is/not/found)\n"
-            "[notfound-relative-link-fragment](http://test.com/this/is/not/found#fragment)\n"
-            "[invalid-absolute-link](http://test.com/www.github.com)\n"
+            "[notfound-relative-link](http://test.com/tree/docs/this/is/not/found)\n"
+            "[notfound-relative-link-fragment](http://test.com/tree/docs/this/is/not/found#fragment)\n"
+            "[notfound-relative-link-dotdot](http://test.com/tree/examples/notfound.txt)\n"
+            "[invalid-absolute-link](http://test.com/tree/docs/www.github.com)\n"
             "[valid-absolute-link](https://website-invalid-random321.net) "
             "[valid-ref-link](#footer)"
         )
@@ -203,6 +204,7 @@ class TestSync(unittest.TestCase):
             "[exists-relative-link-fragment](test.txt#fragment)\n"
             "[notfound-relative-link](./this/is/not/found)\n"
             "[notfound-relative-link-fragment](./this/is/not/found#fragment)\n"
+            "[notfound-relative-link-dotdot](../examples/notfound.txt)\n"
             "[invalid-absolute-link](www.github.com)\n"
             "[valid-absolute-link](https://website-invalid-random321.net) "
             "[valid-ref-link](#footer)"
@@ -221,7 +223,7 @@ class TestSync(unittest.TestCase):
             transform_text(folder=tmpdirname,
                            files={content_file: content_file},
                            base_path="test-content",
-                           base_url="http://test.com")
+                           base_url="http://test.com/tree/docs/")
             # read the result
             actual = ""
             with open(os.path.join(tmpdirname, content_file), 'r') as result:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

For relative URLs that are not matched to a file on disk, we
rewrite them to a github URL. The base URL is joined to the
path with urljoin. If the the path includes a `..` then
urljoin goes up one level from the last `/` in the base URL.
Because of that, we need the base url to end with a `/`.
Added tests to avoid this from breaking in future.

Fixes #186
Fixes #177


Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._

/kind misc