### PR TITLE
Lowercase fragments on local markdown pages

### DIFF
--- a/sync/test_sync.py
+++ b/sync/test_sync.py
@@ -186,28 +186,29 @@ class TestSync(unittest.TestCase):
     def test_transform_text(self):
         """Ensure that transform links will turns links to
         relative github link or existing file name"""
+        self.maxDiff = None
 
         expected = (
             "[exists-relative-link](test-content/test.txt)\n"
             "[exists-relative-link](test-content/content/)\n"
-            "[exists-relative-link-fragment](test-content/test.txt#fragment)\n"
-            "[notfound-relative-link](http://test.com/tree/docs/this/is/not/found)\n"
-            "[notfound-relative-link-fragment](http://test.com/tree/docs/this/is/not/found#fragment)\n"
+            "[exists-relative-link-fragment](test-content/test.txt#Fragment)\n"
+            "[notfound-relative-link](http://test.com/tree/docs/this/is/not/found.txt#FraGment)\n"
+            "[notfound-relative-link-fragment](http://test.com/tree/docs/this/is/not/found.md#fraGmenT)\n"
             "[notfound-relative-link-dotdot](http://test.com/tree/examples/notfound.txt)\n"
             "[invalid-absolute-link](http://test.com/tree/docs/www.github.com)\n"
-            "[valid-absolute-link](https://website-invalid-random321.net) "
+            "[valid-absolute-link](https://website-random321.net#FRagment) "
             "[valid-ref-link](#footer)"
         )
         text = (
             "[exists-relative-link](./test.txt)\n"
             "[exists-relative-link](./content.md)\n"
-            "[exists-relative-link-fragment](test.txt#fragment)\n"
-            "[notfound-relative-link](./this/is/not/found)\n"
-            "[notfound-relative-link-fragment](./this/is/not/found#fragment)\n"
+            "[exists-relative-link-fragment](test.txt#Fragment)\n"
+            "[notfound-relative-link](./this/is/not/found.txt#FraGment)\n"
+            "[notfound-relative-link-fragment](./this/is/not/found.md#fraGmenT)\n"
             "[notfound-relative-link-dotdot](../examples/notfound.txt)\n"
             "[invalid-absolute-link](www.github.com)\n"
-            "[valid-absolute-link](https://website-invalid-random321.net) "
-            "[valid-ref-link](#footer)"
+            "[valid-absolute-link](https://website-random321.net#FRagment) "
+            "[valid-ref-link](#fooTEr)"
         )
 
         content_file = "content.md"

--- a/sync/test_versions.py
+++ b/sync/test_versions.py
@@ -24,7 +24,7 @@ test_config_string = """
 # This is a test config
 component: test
 displayOrder: 0
-repository: https://foo.bar
+repository: https://foo.bar/org/test
 docDirectory: docs
 archive: https://foo.bar/tags
 tags:
@@ -44,7 +44,7 @@ test_config_string_new = """
 # This is a test config
 component: test
 displayOrder: 0
-repository: https://foo.bar
+repository: https://foo.bar/org/test
 docDirectory: docs
 archive: https://foo.bar/tags
 tags:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Hugo produces lowercase anchors into rendered markdown pages.
If a fragment points to a markdown page, make it lower case.
We do not touch fragments on external URLs or on github files
that are not markdown.

Fixes #159

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._

/kind bug