### PR TITLE
Add a nightly deployment for the website

### DIFF
--- a/.github/workflows/nightly-deploy.yml
+++ b/.github/workflows/nightly-deploy.yml
@@ -1,0 +1,14 @@
+name: Trigger Netlify Build
+on:
+  schedule:
+    # Run at 3:15AM UTC daily
+    - cron: '15 3 * * *'
+jobs:
+  build:
+    name: Request Netlify Webhook
+    runs-on: ubuntu-latest
+    steps:
+      - name: Curl request
+        env:
+          NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }} 
+        run: curl -X POST -d {} $NETLIFY_BUILD_HOOK


### PR DESCRIPTION
Use a simple scheduled github action to deploy
the website nightly. The deploy step includes sync,
so this will pull in an up to date version of the docs
on the master branch.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
