### PR TITLE
Add a version rm command to versions

### DIFF
--- a/sync/README.md
+++ b/sync/README.md
@@ -105,7 +105,8 @@ docker build -t tekton/web sync/.
 
 ## `versions`
 
-The `versions` script can be used to add a new version to the `sync` configurations.
+The `versions` script can be used to add a new version or remove an unwanted
+one from the `sync` configurations.
 It was designed to be integrated in the release process of Tekton projects.
 
 To run this script locally, set up a Python 3 environment and execute
@@ -122,16 +123,30 @@ pip3 install -r requirements.txt
 
 ## Usage
 
+The script provides online help via the `--help` flag.
+Use `[command] --help` for help on the specific command (`add` or `rm`).
+
 ```bash
-USAGE: ./sync/versions.py [flags]
+$ ./sync/versions.py
+Usage: versions.py [OPTIONS] COMMAND [ARGS]...
 
-flags:
+Options:
+  --help  Show this message and exit.
 
-./sync/versions.py:
-  -p,--project: Name of the component
-    (default: 'pipeline')
-  -r,--version: Version of the component
-  -c,--config: Config directory
+Commands:
+  add  add a new version in the config for the specified project
+  rm   remove a version from the config for the specified project
+```
 
-Try --helpfull to get a list of all flags.
+## Examples:
+
+Adding a new version to the pipeline project:
+```bash
+$ ./sync/versions.py add v0.18.0
+```
+
+Adding a new minor to the triggers project, and remove the old one:
+```bash
+$ ./sync/versions.py add v0.9.1 --project triggers
+$ ./sync/versions.py rm v0.9.0 --project triggers
 ```

--- a/sync/requirements.txt
+++ b/sync/requirements.txt
@@ -3,9 +3,9 @@ ruamel.yaml==0.16.12
 google-cloud-storage==1.23.0
 Jinja2==2.11.1
 google-auth==1.14.0
-absl-py==0.9.0
 urlopen==1.0.0
 markdown==3.1.1
 lxml==4.5.2
 coverage==5.3
 flake8==3.8.3
+click==7.1.2

--- a/sync/sync.py
+++ b/sync/sync.py
@@ -31,29 +31,20 @@ from urllib.error import URLError
 from urllib.parse import urlparse, urljoin, urlunparse
 import wget
 
-from absl import app
-from absl import flags
+import click
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 from lxml import etree
 from ruamel.yaml import YAML
 
 
-FLAGS = flags.FLAGS
-
-# Flag names are globally defined!  So in general, we need to be
-# careful to pick names that are unlikely to be used by other libraries.
-# If there is a conflict, we'll get an error at import time.
-flags.DEFINE_string(
-    'config',
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config'),
-    'Config directory', short_name='c')
-
 CONTENT_DIR = './content/en/docs'
 JS_ASSET_DIR = './assets/js'
 TEMPLATE_DIR = './templates'
 VAULT_DIR = './content/en/vault'
-BUCKET_NAME = 'tekton-website-assets'
+
+DEFAULT_CONFIG_FOLDER = os.path.join(os.path.dirname(
+    os.path.abspath(__file__)), 'config')
 
 jinja_env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
 
@@ -276,11 +267,13 @@ def create_resource(dest_prefix, file, versions):
     with open(f'{dest_prefix}/{file}', 'w') as f:
         f.write(resource)
 
-
-def sync(argv):
+@click.command()
+@click.option('--config-folder', default=DEFAULT_CONFIG_FOLDER,
+              help='the folder that contains the config files')
+def sync(config_folder):
     """ fetch all the files and sync it to the website """
     # get the path of the urls needed
-    config_files = get_files(f'{FLAGS.config}', ".yaml")
+    config_files = get_files(config_folder, ".yaml")
     config = [x["content"] for x in load_config(config_files)]
     # download resources
     download_resources_to_project(config)
@@ -292,4 +285,4 @@ def sync(argv):
 
 
 if __name__ == '__main__':
-    app.run(sync)
+    sync()

--- a/sync/test_sync.py
+++ b/sync/test_sync.py
@@ -97,8 +97,6 @@ class TestSync(unittest.TestCase):
         """ convert a list of files into a list of dictionaries """
         # create a tmp file with yaml txt
         text = "{displayOrder: 1}"
-        actual = None
-        tmp_name = None
 
         with tempfile.NamedTemporaryFile(dir='/tmp', delete=False) as tmp:
             tmp_name = tmp.name
@@ -121,8 +119,6 @@ class TestSync(unittest.TestCase):
     def test_get_files(self):
         """ create a list of files within a
         directory that contain a valid extension"""
-        expected = None
-        actual = None
 
         with tempfile.NamedTemporaryFile(dir='/tmp', delete=True) as tmp:
             expected = [tmp.name]
@@ -225,7 +221,6 @@ class TestSync(unittest.TestCase):
                            base_path="test-content",
                            base_url="http://test.com/tree/docs/")
             # read the result
-            actual = ""
             with open(os.path.join(tmpdirname, content_file), 'r') as result:
                 actual = result.read()
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We may need to remove versions: when releasing a minor version
we might want to remove previous releases on the same major version.
Adding a version rm command for that.

As part of the process, move away from absl-py and use click instead
that helps handling different commands.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._

/kind feature