### PR TITLE
Fix the case of non-md files in nested folders

### DIFF
--- a/sync/sync.py
+++ b/sync/sync.py
@@ -266,16 +266,16 @@ def transform_link(link, base_path, local_files, rewrite_path, rewrite_url):
         if ext == '.md':
             # Links to the index file are rendered as base_path/
             if is_index:
-                path = ''
+                target_file = ''
             # links to md other files are rendered as .../[md filename]/
             else:
-                path = filename + '/'
+                target_file = filename + '/'
             # for .md files, lower the case of fragments to match hugo's behaviour
             parsed = parsed._replace(fragment=parsed.fragment.lower())
         if target_folder:
-            new_path = [rewrite_path, target_folder, path]
+            new_path = [rewrite_path, target_folder, target_file]
         else:
-            new_path = [rewrite_path, path]
+            new_path = [rewrite_path, target_file]
         return parsed._replace(path="/".join(new_path)).geturl()
     # when not found on disk, append to the base_url
     return urljoin(rewrite_url, parsed._replace(path=fq_path).geturl())

--- a/sync/test_sync.py
+++ b/sync/test_sync.py
@@ -225,7 +225,9 @@ class TestSync(unittest.TestCase):
         local_files = {
             'test-content/content.md': ('_index.md', ''),
             'test-content/test.txt': ('test.txt', ''),
-            'another-content/test.md': ('test.md', 'another')
+            'another-content/test.md': ('test.md', 'another'),
+            'test-content/nested/content.md': ('content.md', 'nested'),
+            'test-content/nested/example.yaml': ('example.yaml', 'nested')
         }
 
         cases = [
@@ -234,7 +236,9 @@ class TestSync(unittest.TestCase):
             "test.txt",
             "content.md",
             "notthere.txt",
-            "../another-content/test.md"
+            "../another-content/test.md",
+            "./nested/content.md",
+            "./nested/example.yaml"
         ]
 
         expected_results = [
@@ -243,7 +247,9 @@ class TestSync(unittest.TestCase):
             "/docs/foo/test.txt",
             "/docs/foo/",
             "https://foo.bar/test-content/notthere.txt",
-            "/docs/foo/another/test/"
+            "/docs/foo/another/test/",
+            "/docs/foo/nested/content/",
+            "/docs/foo/nested/example.yaml"
         ]
 
         for case, expected in zip(cases, expected_results):
@@ -384,6 +390,7 @@ class TestSync(unittest.TestCase):
             site_folder=f'{sync.CONTENT_DIR}/test',
             base_path='/docs/test',
             base_url=f'http://test.com/test/tree/{self.tagname}/')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In case of non-md files in nested folders, the filename used in the
rewrite included the target path leading to double-path in the link.
Fixed that and added a use case for the non-md file in a subfolder.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._

/kind bug