### PR TITLE
Try utf-8 first when decoding text

### DIFF
--- a/sync/sync.py
+++ b/sync/sync.py
@@ -186,7 +186,7 @@ def transform_doc(doc, source_folder, target, target_folder, header,
     return target
 
 
-def decode(s, encodings=('ascii', 'utf8', 'latin1')):
+def decode(s, encodings=('utf8', 'latin1', 'ascii')):
     for encoding in encodings:
         try:
             return s.decode(encoding)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

There is a chance that utf-8 encoded text may be decoded
successfully but wrongly as ascii. UTF-8 instead should always be
able to decode ascii successfully, so let's try UTF-8 first.

Fixes: #211

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._

/kind bug