### PR TITLE
Fix the baseURL for dev and prod use caes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ sync:
 .PHONY: serve
 serve:
 	hugo server \
+	--baseURL $(URL) \
 	--buildDrafts \
 	--buildFuture \
 	--disableFastRender \
@@ -13,7 +14,7 @@ serve:
 
 .PHONY: production-build
 production-build: sync
-	hugo
+	hugo --baseURL $(URL)
 
 .PHONY: preview-build
 preview-build: sync

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,15 @@
 [build]
-publish = "public"
-command = "make production-build"
+  publish = "public"
+  command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.53"
+  HUGO_VERSION = "0.53"
+
+[dev]
+  command = "make serve URL=http://localhost:8888/"
 
 [context.deploy-preview]
-command = "make preview-build"
+  command = "make preview-build"
 
 [context.branch-deploy]
-command = "make preview-build"
+  command = "make preview-build"


### PR DESCRIPTION
# Changes

The baseURL is not set for dev and prod which causes the following
issues:
- for dev, the URL shown on the console is not the correct one
- for prod, the generated sitemap.xml uses relative URLs, which
  makes it not parsable by the search engine

This is already setup correctly for deploy-previews.

Partially fixes #191

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._

/cc @vdemeester 