### PR TITLE
Enable index, follow in the production website

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,11 +5,17 @@
 [build.environment]
   HUGO_VERSION = "0.53"
 
-[dev]
-  command = "make serve URL=http://localhost:8888/"
+[context.production.environment]
+  HUGO_ENV = "production"
 
 [context.deploy-preview]
+  HUGO_ENV = "staging"
   command = "make preview-build"
 
 [context.branch-deploy]
   command = "make preview-build"
+
+
+
+[dev]
+  command = "make serve URL=http://localhost:8888/"


### PR DESCRIPTION
# Changes

The website header partial sets the meta index, follow if the
HUGO_ENV is set to production, and no index no follow otherwise.

Change the HUGO_ENV to be production for the production environment.

Related to #191

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._

/cc @vdemeester @AlanGreene 