### PR TITLE
Fix install instructions for deb-based distros

### DIFF
--- a/content/en/docs/Getting Started/_index.md
+++ b/content/en/docs/Getting Started/_index.md
@@ -218,7 +218,7 @@ rpm-based distros).
     ```bash
     # Replace LINK-TO-THE-PACKAGE with the package URL you would like to use.
     curl -LO LINK-TO-THE-PACKAGE
-    sudo apt install ./PACKAGE-NAME
+    sudo dpkg -i ./PACKAGE-NAME
     ```
 
     If you are using the latest releases of Ubuntu or Debian, you may use the

--- a/content/en/docs/Getting Started/_index.md
+++ b/content/en/docs/Getting Started/_index.md
@@ -217,7 +217,8 @@ rpm-based distros).
 
     ```bash
     # Replace LINK-TO-THE-PACKAGE with the package URL you would like to use.
-    rpm -Uvh LINK-TO-THE-PACKAGE
+    curl -LO LINK-TO-THE-PACKAGE
+    sudo apt install ./PACKAGE-NAME
     ```
 
     If you are using the latest releases of Ubuntu or Debian, you may use the


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

"apt" is used to install packages on deb-based distros, not "rpm", which is used on rpm-based distros.

"apt" is not able to install individual packages from a URL; the package has to be downloaded prior to be
installed. curl (instead of wget) is used as it is the tool used later in the same page to get the LINK-TO-TARBALL.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
