### PR TITLE
fix broken link in getting-started tutorial

### DIFF
--- a/tutorials/katacoda/getting-started/concepts.md
+++ b/tutorials/katacoda/getting-started/concepts.md
@@ -7,4 +7,4 @@ For example, if you plan to build a CI/CD system that builds source code
 from your GitHub repository into a container image, the Tekton pipeline may
 look as follows:
 
-![architecture](https://github.com/tektoncd/website/tree/main/tutorials/katacoda/getting-started/images/architecture.png?raw=true)
+![architecture](https://raw.githubusercontent.com/tektoncd/website/main/tutorials/katacoda/getting-started/images/architecture.png)


### PR DESCRIPTION
This PR fixes a broken link to an image of an architecture diagram.

Closes: #246

Signed-off-by: Steve Martinelli <s.martinelli@gmail.com>
