### PR TITLE
Fix broken links in lists and indented text

### DIFF
--- a/sync/requirements.txt
+++ b/sync/requirements.txt
@@ -5,9 +5,9 @@ Jinja2==2.11.1
 google-auth==1.14.0
 urlopen==1.0.0
 markdown==3.1.1
-lxml==4.5.2
 coverage==5.3
 flake8==3.8.3
 click>=7.1.2
 gitpython>=3.1.11
 gitdb-speedups>=0.1.0
+beautifulsoup4==4.9.3


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When replacing links, we parse the markdown document line by line. When
the markdown parsers encounters an indented line, without the context of
the surrounding lines, it assumes a code block and does not render the
links to html, which means we do not re-write those links.

This patch fixes the issue by stripping left spaces in the text
fragments sent to "get_links", so that we can extract links successfully
and preserve the spaces in the rendered markdown.

Fixes: #229

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._

/kind bug
/cc @AlanGreene