### PR TITLE
Add triggers v0.11.2, v0.12.1, v0.13.0 and v0.14.1

### DIFF
--- a/sync/config/triggers.yaml
+++ b/sync/config/triggers.yaml
@@ -30,10 +30,62 @@ archive: https://github.com/tektoncd/triggers/tags
 #       header: <dict>         # optional, no header added if not set
 #         See https://www.docsy.dev/docs/adding-content/navigation/#section-menu
 tags:
-- name: v0.10.1
+- name: origin/release-v0.14.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
-  displayName: v0.10.1
+  displayName: v0.14.1
+  # Dict of folders to sync
+  folders:
+    docs:
+      index: README.md
+      include: ['*.md']
+    docs/getting-started:
+      target: getting-started
+      include:
+      - create-ingress.yaml
+- name: origin/release-v0.13.x
+  # The name to display on tekton.dev.
+  # sync.py will use this value in the version switcher and other places.
+  displayName: v0.13.0
+  # Dict of folders to sync
+  folders:
+    docs:
+      index: README.md
+      include: ['*.md']
+    docs/getting-started:
+      target: getting-started
+      include:
+      - create-ingress.yaml
+- name: origin/release-v0.12.x
+  # The name to display on tekton.dev.
+  # sync.py will use this value in the version switcher and other places.
+  displayName: v0.12.1
+  # Dict of folders to sync
+  folders:
+    docs:
+      index: README.md
+      include: ['*.md']
+    docs/getting-started:
+      target: getting-started
+      include:
+      - create-ingress.yaml
+- name: origin/release-v0.11.x
+  # The name to display on tekton.dev.
+  # sync.py will use this value in the version switcher and other places.
+  displayName: v0.11.2
+  # Dict of folders to sync
+  folders:
+    docs:
+      index: README.md
+      include: ['*.md']
+    docs/getting-started:
+      target: getting-started
+      include:
+      - create-ingress.yaml
+- name: v0.10.2
+  # The name to display on tekton.dev.
+  # sync.py will use this value in the version switcher and other places.
+  displayName: v0.10.2
   # Dict of folders to sync
   folders:
     docs:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The website lists v0.10.1 as the latest release of triggers. This PR adds v0.11.2, v0.12.1, v0.13.0 to the sync config.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)