### PR TITLE
fix broken links about Kubernetes pod

### DIFF
--- a/content/en/docs/Concepts/_index.md
+++ b/content/en/docs/Concepts/_index.md
@@ -44,7 +44,7 @@ each step with a container image you provide. For example, you may use the
 in the same manner as you would on your local workstation (`go build`).
 
 A **task** is a collection of **steps** in order. Tekton runs a task in
-the form of a [Kubernetes pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/),
+the form of a [Kubernetes pod](https://kubernetes.io/docs/concepts/workloads/pods/),
 where each step becomes a running container in the pod. This design allows you
 to set up a shared environment for a number of related steps; for example,
 you may mount a [Kubernetes volume](https://kubernetes.io/docs/concepts/storage/volumes/)

--- a/content/en/docs/Getting Started/_index.md
+++ b/content/en/docs/Getting Started/_index.md
@@ -271,7 +271,7 @@ sudo tar xvzf YOUR-DOWNLOADED-FILE -C /usr/local/bin/ tkn
 
 With Tekton, each operation in your CI/CD workflow becomes a `Step`,
 which is executed with a container image you specify. `Steps` are then
-organized in `Tasks`, which run as a [Kubernetes pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/)
+organized in `Tasks`, which run as a [Kubernetes pod](https://kubernetes.io/docs/concepts/workloads/pods/)
 in your cluster. You can further organize `Tasks` into `Pipelines`, which 
 can control the order of execution of several `Tasks`. 
 

--- a/content/en/docs/Getting Started/pipelines.md
+++ b/content/en/docs/Getting Started/pipelines.md
@@ -14,7 +14,7 @@ description: >
 
 As you learned previously, with Tekton, each operation in your CI/CD workflow becomes a `Step`,
 which is executed with a container image you specify. `Steps` are then
-organized in `Tasks`, which run as a [Kubernetes pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/)
+organized in `Tasks`, which run as a [Kubernetes pod](https://kubernetes.io/docs/concepts/workloads/pods/)
 in your cluster. You can further organize `Tasks` into `Pipelines`, which 
 can control the order of execution of several `Tasks`. 
 

--- a/tutorials/katacoda/basic-pipeline/step2.md
+++ b/tutorials/katacoda/basic-pipeline/step2.md
@@ -6,7 +6,7 @@ example. (after you're done just imagine what you could do!)
 
 As you learned previously, with Tekton, each operation in your CI/CD workflow becomes a `Step`,
 which is executed with a container image you specify. `Steps` are then
-organized in `Tasks`, which run as a [Kubernetes pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/)
+organized in `Tasks`, which run as a [Kubernetes pod](https://kubernetes.io/docs/concepts/workloads/pods/)
 in your cluster. You can further organize `Tasks` into `Pipelines`, which 
 can control the order of execution of several `Tasks`. 
 


### PR DESCRIPTION
Signed-off-by: shaowenchen <mail@chenshaowen.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/ is modified to https://kubernetes.io/docs/concepts/workloads/pods/

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
