### PR TITLE
Fix mime type detection when running on ubuntu 🔎

### DIFF
--- a/sync/sync.py
+++ b/sync/sync.py
@@ -171,7 +171,9 @@ def transform_doc(doc, source_folder, target, target_folder, header,
     :param base_url: used to rewrite relative links to unknown files
     :param site_folder: the root folder on disk where files shall be written to
     """
-    if doc.mime_type != 'text/plain':
+    # Some machines seem to use text/plain (e.g. running on a mac) and some use
+    # text/markdown (e.g. running in a fresh ubuntu container)
+    if doc.mime_type != 'text/plain' and doc.mime_type != 'text/markdown':
         logging.error(f'Cannot process {doc.mime_type} file {doc.path}')
         sys.exit(1)
     site_target_folder = os.path.normpath(os.path.join(site_folder, target_folder))


### PR DESCRIPTION
# Changes

Was working with @geriom to get this running on his ubuntu machine -
when run on a ubuntu machine (still not sure why netflify isnt havign
the same issue), the script fails with errors such as:

```
ERROR:root:Cannot process text/markdown file docs/logs.md
```

I reproduced this by running an `ubuntu` docker container and
following along with [the DEVELOPMENT.md](https://github.com/tektoncd/website/blob/main/DEVELOPMENT.md)
and go the same errors! It seems that when I run on my mac, the mime
type of each file is `text/plain` and when I run on ubuntu the mimetype
is `text/markdown`. I'm not sure WHY this difference is happening (e.g.
the installed `gitpython` versions were the same) but since
`text/markdown` seems like a valid type for markdown files, maybe we can
just support both!

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
