### PR TITLE
Pin Pipelines version in Katacoda tutorials for compatibility with k8s 1.18

### DIFF
--- a/tutorials/katacoda/basic-pipeline/init.sh
+++ b/tutorials/katacoda/basic-pipeline/init.sh
@@ -5,7 +5,9 @@ sleep 1
 launch.sh
 
 # Install Tekton Pipelines
-kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+# kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+# Pin to v0.26 since that's the last supported release on Kubernetes 1.18 (environment provided by Katacoda)
+kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.26.0/release.yaml
 
 # Install the Tekton CLI
 curl -LO https://github.com/tektoncd/cli/releases/download/v0.18.0/tkn_0.18.0_Linux_x86_64.tar.gz

--- a/tutorials/katacoda/basic-pipeline/step1.md
+++ b/tutorials/katacoda/basic-pipeline/step1.md
@@ -13,8 +13,6 @@ spec:
   steps:
     - name: hello
       image: ubuntu
-      command:
-        - echo
       script: |
         set -e
         echo "Hello World!"

--- a/tutorials/katacoda/dashboard/step1.md
+++ b/tutorials/katacoda/dashboard/step1.md
@@ -11,7 +11,9 @@ Now, let's begin!
 ## Install the Tekton Dashboard Prerequisites
 
 - [Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/main/docs/install.md)
-`kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml`{{execute}}
+<!-- `kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml`{{execute}} -->
+<!-- Pin to v0.26 since that's the last supported release on Kubernetes 1.18 (environment provided by Katacoda) -->
+`kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.26.0/release.yaml`{{execute}}
 
 Verify the pods are running:
 `kubectl get pods -n tekton-pipelines`{{execute}}

--- a/tutorials/katacoda/getting-started/resources.md
+++ b/tutorials/katacoda/getting-started/resources.md
@@ -15,7 +15,7 @@ spec:
   params:
   # The revision/branch of the repository
   - name: revision
-    value: master
+    value: main
   # The URL of the repository
   - name: url
     value: https://github.com/tektoncd/website

--- a/tutorials/katacoda/getting-started/setup.md
+++ b/tutorials/katacoda/getting-started/setup.md
@@ -18,7 +18,9 @@ KubeDNS is running at ...
 To add Tekton to this experimental Kubernetes cluster, execute the command
 below:
 
-`kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml`{{execute}}
+<!-- `kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml`{{execute}} -->
+<!-- Pin to v0.26 since that's the last supported release on Kubernetes 1.18 (environment provided by Katacoda) -->
+`kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.26.0/release.yaml`{{execute}}
 
 It may take a few moments for the installation to complete. To monitor the
 progress, run the following command:

--- a/tutorials/katacoda/playground/background.sh
+++ b/tutorials/katacoda/playground/background.sh
@@ -6,7 +6,9 @@ launch.sh
 echo "done" >> /opt/.clusterstarted
 
 echo "Installing Tekton Pipelines"
-kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+# kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+# Pin to v0.26 since that's the last supported release on Kubernetes 1.18 (environment provided by Katacoda)
+kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.26.0/release.yaml
 
 mkdir /mnt/data
 

--- a/tutorials/katacoda/runs/init.sh
+++ b/tutorials/katacoda/runs/init.sh
@@ -2,7 +2,10 @@
 launch.sh
 # Installs Tekton in the Kubernetes cluster
 ## Tekton pipelines
-kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+# kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+# Pin to v0.26 since that's the last supported release on Kubernetes 1.18 (environment provided by Katacoda)
+kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.26.0/release.yaml
+
 # Sets up persistent volumes
 mkdir /mnt/data && kubectl apply -f https://k8s.io/examples/pods/storage/pv-volume.yaml
 kubectl delete configmap/config-artifact-pvc -n tekton-pipelines

--- a/tutorials/katacoda/runs/io.md
+++ b/tutorials/katacoda/runs/io.md
@@ -65,7 +65,7 @@ spec:
   params:
   # The revision/branch of the repository
   - name: revision
-    value: master
+    value: main
   # The URL of the repository
   - name: url
     value: https://github.com/tektoncd/website

--- a/tutorials/katacoda/runs/src/tekton-katacoda/pipelineResources/git.yaml
+++ b/tutorials/katacoda/runs/src/tekton-katacoda/pipelineResources/git.yaml
@@ -8,7 +8,7 @@ spec:
   params:
   # The revision/branch of the repository
   - name: revision
-    value: master
+    value: main
   # The URL of the repository
   - name: url
     value: https://github.com/tektoncd/website/

--- a/tutorials/katacoda/tasks/init.sh
+++ b/tutorials/katacoda/tasks/init.sh
@@ -2,7 +2,10 @@
 launch.sh
 # Installs Tekton in the Kubernetes cluster
 ## Tekton pipelines
-kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+# kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+# Pin to v0.26 since that's the last supported release on Kubernetes 1.18 (environment provided by Katacoda)
+kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.26.0/release.yaml
+
 # Sets up persistent volumes
 mkdir /mnt/data && kubectl apply -f https://k8s.io/examples/pods/storage/pv-volume.yaml
 kubectl delete configmap/config-artifact-pvc -n tekton-pipelines

--- a/tutorials/katacoda/tasks/io.md
+++ b/tutorials/katacoda/tasks/io.md
@@ -52,7 +52,7 @@ spec:
   params:
   # The revision/branch of the repository
   - name: revision
-    value: master
+    value: main
   # The URL of the repository
   - name: url
     value: https://github.com/tektoncd/website

--- a/tutorials/katacoda/tasks/src/tekton-katacoda/pipelineResources/git.yaml
+++ b/tutorials/katacoda/tasks/src/tekton-katacoda/pipelineResources/git.yaml
@@ -8,7 +8,7 @@ spec:
   params:
   # The revision/branch of the repository
   - name: revision
-    value: master
+    value: main
   # The URL of the repository
   - name: url
     value: https://github.com/tektoncd/website/


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/website/issues/290

The Kubernetes environment provided by Katacoda is version 1.18. Tekton Pipelines
releases from v0.27 require a minimum of Kubernetes 1.19. Since the tutorials
currently install the 'latest' release this means they are broken.

Pin the Pipelines release version to v0.26 since this is last release that supports
Kubernetes 1.18. In future we may need to adopt a different approach to building
these tutorial environments so we have more flexibility on the Kubernetes version.

Deployed these changes to a test Katacoda profile: https://katacoda.com/alangreene-tektoncd

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
