### PR TITLE
[wip] Add operator to the list of published docs

### DIFF
--- a/sync/config/operator.yaml
+++ b/sync/config/operator.yaml
@@ -1,0 +1,50 @@
+# Each YAML file under sync/ configures how sync/sync.py synchronizes
+# contents of various versions from its source of truth (usually a GitHub
+# repository of a Tekton component, such as tektoncd/pipelines) to
+# content/ (for the lastest version) and vault/ (for earlier versions).
+
+# The name of the component.
+# sync.py will use this value to build directories in content/ and vault/.
+component: Operator
+# The order of the component.
+displayOrder: 4
+# The GitHub repository where documentation resides.
+repository: https://github.com/tektoncd/operator
+# The directory in the GitHub repository where contents reside.
+docDirectory: docs
+# The link to the GitHub tag page.
+archive: https://github.com/tektoncd/operator/tags
+# The tags (versions) of contents to sync.
+# Note that sync.py and related script reads tags in the order specified in
+# the following list; the first entry in tags will automatically become the
+# latest version of contents.
+# To add a new version, append to the list as below
+# - name: vX.Y.Z
+#   displayName: vX.Y.Z
+#   folders:
+#     docs:
+#       target: '/'            # optional, default value '/'
+#       index: README.md       # optional, if _index.md exists
+#       include: ['*.md']      # optional, default value ['*']
+#       exclude: ['not_in.md'] # optional, default value []
+#       header: <dict>         # optional, no header added if not set
+#         See https://www.docsy.dev/docs/adding-content/navigation/#section-menu
+tags:
+- name: v0.49.0
+  # The name to display on tekton.dev.
+  # helper.py will use this value in the version switcher and other places.
+  displayName: v0.49.0
+  # Dict of folders to sync
+  folders:
+    docs:
+      index: README.md
+      include: ['*.md']
+- name: main
+  # The name to display on tekton.dev.
+  # helper.py will use this value in the version switcher and other places.
+  displayName: main
+  # Dict of folders to sync
+  folders:
+    docs:
+      index: README.md
+      include: ['*.md']


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

An update is needed in `tektoncd/operator` before we can enable this. Also, I think we should wait for 0.50.0 release. But I wanted to get early feedback and mainly see if this is the only thing to be added to add operator docs to the website.

/cc @AlanGreene @afrittoli 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
