### PR TITLE
Add git version prerequisite to DEVELOPMENT.md.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,6 +46,7 @@ docker-compose rm
 * [python3](https://www.python.org/downloads/) 
 * [hugo (EXTENDED VERSION)](https://github.com/gohugoio/hugo/releases)
 * [pip](https://pip.pypa.io/en/stable/installing/)
+* [git 1.8.5 or later](https://github.com/git/git/releases)
 * [npm v6.14.5](https://nodejs.org/en/)
 * [node v14.3.0](https://nodejs.org/en/)
 * [netlify cli](https://cli.netlify.com/getting-started)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
sync/sync.py fails if the installed git version is older than 1.8.5.
That is because sync/sync.py calls git command with -C option internally, and the option was
introduced at git 1.8.5. 1.8.5 is quite old but the default git version is older than it in certain
Linux distribution. Adding git version prerequisite could be more developer-friendly.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
