### PR TITLE
Delete unnecessary closing tag

### DIFF
--- a/layouts/shortcodes/tutorial.html
+++ b/layouts/shortcodes/tutorial.html
@@ -6,5 +6,4 @@
         <div class="btn btn-success" type="button">Launch Interactive Tutorial</div>
     </a>
     {{ partial "tutorial-modal.html" }}
-    </div>
 </div>


### PR DESCRIPTION
Delete dangling div tag in the tutorial shortcode code that causes the
footer to not render correctly in some pages.

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
