### PR TITLE
Match the remote ref names when looking for branches

### DIFF
--- a/sync/README.md
+++ b/sync/README.md
@@ -15,14 +15,14 @@ the script:
 
 ```bash
 python3 -m venv .venv
-source .venv/bin/activate    
+source .venv/bin/activate
 pip3 install -r requirements.txt
 ./sync/sync.py
 ```
 
 **Note:** Follow [these steps](../DEVELOPMENT.md) to run the entire website locally.
 
-### Usage
+### Usage of Sync
 
 ```bash
        USAGE: sync.py [flags]
@@ -75,7 +75,7 @@ archive: https://github.com/tektoncd/foobar/tags
 #  files:
 #  - myfiles.md: myfiles.md
 tags:
-  # The name of the tag in the GitHub repository.
+  # The name of a tag or branch in the GitHub repository.
 - name: master
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
@@ -113,14 +113,14 @@ the script:
 
 ```bash
 python3 -m venv .venv
-source .venv/bin/activate    
+source .venv/bin/activate
 pip3 install -r requirements.txt
 ./sync/versions.py add --project <project-name> <version-name>
 ```
 
 **Note:** Follow [these steps](../DEVELOPMENT.md) to run the entire website locally.
 
-## Usage
+## Usage of Versions
 
 The script provides online help via the `--help` flag.
 Use `[command] --help` for help on the specific command (`add` or `rm`).
@@ -137,15 +137,17 @@ Commands:
   rm   remove a version from the config for the specified project
 ```
 
-## Examples:
+## Examples
 
 Adding a new version to the pipeline project:
+
 ```bash
-$ ./sync/versions.py add v0.18.0 --project pipeline
+./sync/versions.py add v0.18.0 --project pipeline
 ```
 
 Adding a new minor to the triggers project, and remove the old one:
+
 ```bash
-$ ./sync/versions.py add v0.9.1 --project triggers
-$ ./sync/versions.py rm v0.9.0 --project triggers
+./sync/versions.py add v0.9.1 --project triggers
+./sync/versions.py rm v0.9.0 --project triggers
 ```

--- a/sync/config/operator.yaml
+++ b/sync/config/operator.yaml
@@ -30,7 +30,7 @@ archive: https://github.com/tektoncd/operator/tags
 #       header: <dict>         # optional, no header added if not set
 #         See https://www.docsy.dev/docs/adding-content/navigation/#section-menu
 tags:
-  - name: origin/release-v0.50.x
+  - name: release-v0.50.x
     # The name to display on tekton.dev.
     # helper.py will use this value in the version switcher and other places.
     displayName: v0.50.1

--- a/sync/config/pipelines.yaml
+++ b/sync/config/pipelines.yaml
@@ -30,7 +30,7 @@ archive: https://github.com/tektoncd/pipeline/tags
 #       header: <dict>         # optional, no header added if not set
 #         See https://www.docsy.dev/docs/adding-content/navigation/#section-menu
 tags:
-- name: origin/release-v0.29.x
+- name: release-v0.29.x
   displayName: v0.29.0
   # Dict of folders to sync
   folders:
@@ -40,7 +40,7 @@ tags:
       exclude:
       - api-spec.md
       - tutorial.md
-- name: origin/release-v0.28.x
+- name: release-v0.28.x
   displayName: v0.28.2
   # Dict of folders to sync
   folders:
@@ -50,7 +50,7 @@ tags:
       exclude:
       - api-spec.md
       - tutorial.md
-- name: origin/release-v0.27.x
+- name: release-v0.27.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.27.3
@@ -86,7 +86,7 @@ tags:
       exclude:
       - api-spec.md
       - tutorial.md
-- name: origin/release-v0.24.x
+- name: release-v0.24.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.24.3
@@ -98,7 +98,7 @@ tags:
       exclude:
       - api-spec.md
       - tutorial.md
-- name: origin/release-v0.23.x
+- name: release-v0.23.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.23.0
@@ -110,7 +110,7 @@ tags:
       exclude:
       - api-spec.md
       - tutorial.md
-- name: origin/release-v0.22.x
+- name: release-v0.22.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.22.0
@@ -122,7 +122,7 @@ tags:
       exclude:
       - api-spec.md
       - tutorial.md
-- name: origin/release-v0.21.x
+- name: release-v0.21.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.21.0
@@ -134,7 +134,7 @@ tags:
       exclude:
       - api-spec.md
       - tutorial.md
-- name: origin/release-v0.20.x
+- name: release-v0.20.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.20.1
@@ -146,7 +146,7 @@ tags:
       exclude:
       - api-spec.md
       - tutorial.md
-- name: origin/release-v0.19.x
+- name: release-v0.19.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.19.0
@@ -158,7 +158,7 @@ tags:
       exclude:
       - api-spec.md
       - tutorial.md
-- name: origin/release-v0.18.x
+- name: release-v0.18.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.18.1
@@ -171,7 +171,7 @@ tags:
       - api-spec.md
       - install.md
       - tutorial.md
-- name: origin/release-v0.17.x
+- name: release-v0.17.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.17.3
@@ -187,7 +187,7 @@ tags:
       - runs.md
       - tekton-bundle-contracts.md
       - tutorial.md
-- name: origin/release-v0.16.x
+- name: release-v0.16.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.16.3
@@ -201,7 +201,7 @@ tags:
       - install.md
       - runs.md
       - tutorial.md
-- name: origin/release-v0.15.x
+- name: release-v0.15.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.15.2
@@ -214,7 +214,7 @@ tags:
       - deprecations.md
       - install.md
       - tutorial.md
-- name: origin/release-v0.14.x
+- name: release-v0.14.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.14.3

--- a/sync/config/triggers.yaml
+++ b/sync/config/triggers.yaml
@@ -41,7 +41,7 @@ tags:
       target: getting-started
       include:
       - create-ingress.yaml
-- name: origin/release-v0.16.x
+- name: release-v0.16.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.16.1
@@ -54,7 +54,7 @@ tags:
       target: getting-started
       include:
       - create-ingress.yaml
-- name: origin/release-v0.15.x
+- name: release-v0.15.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.15.2
@@ -67,7 +67,7 @@ tags:
       target: getting-started
       include:
       - create-ingress.yaml
-- name: origin/release-v0.14.x
+- name: release-v0.14.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.14.2
@@ -80,7 +80,7 @@ tags:
       target: getting-started
       include:
       - create-ingress.yaml
-- name: origin/release-v0.13.x
+- name: release-v0.13.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.13.0
@@ -93,7 +93,7 @@ tags:
       target: getting-started
       include:
       - create-ingress.yaml
-- name: origin/release-v0.12.x
+- name: release-v0.12.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.12.1
@@ -106,7 +106,7 @@ tags:
       target: getting-started
       include:
       - create-ingress.yaml
-- name: origin/release-v0.11.x
+- name: release-v0.11.x
   # The name to display on tekton.dev.
   # sync.py will use this value in the version switcher and other places.
   displayName: v0.11.2

--- a/sync/sync.py
+++ b/sync/sync.py
@@ -109,11 +109,11 @@ def transform_docs(git_repo, tag, folders, site_folder, base_path, base_url):
     try:
         tag = next(x for x in git_repo.tags if x.name == tag)
     except StopIteration:
-        # When no tag is found try to match a branch (references)
+        # When no tag is found try to match a branch (remote heads)
         try:
-            tag = next(x for x in git_repo.references if x.name == tag)
+            tag = next(x for x in git_repo.remote().refs if x.remote_head == tag)
         except StopIteration:
-            logging.error(f'No tag {tag} found in {git_repo}')
+            logging.error(f'No tag or branch {tag} found in {git_repo}')
             sys.exit(1)
 
     # List all relevant blobs based on the folder config


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We used to check for reference names in the sync script, which required
the branch name to be configured as "origin/<branch-name>".
This approach broke some of the links.
Fix the sync script by looking for remote ref names in the python git
wrapper, and changing all config to use branch name only.

Fixes #313

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
