### PR TITLE
Fix the case of similar links in one page

### DIFF
--- a/sync/sync.py
+++ b/sync/sync.py
@@ -230,7 +230,7 @@ def transform_links_doc(text, base_path, local_files, rewrite_path, rewrite_url)
     rewrite_map = {x.get("href"): transform_link(x.get("href"), base_path, local_files, rewrite_path, rewrite_url)
         for x in links if x.get("href")}
     for source, target in rewrite_map.items():
-        text = text.replace(source, target)
+        text = text.replace(f'({source})', f'({target})')
     return text
 
 

--- a/sync/test_sync.py
+++ b/sync/test_sync.py
@@ -230,6 +230,7 @@ class TestSync(unittest.TestCase):
         rewrite_url = 'https://foo.bar'
         local_files = {
             'test-content/content.md': ('_index.md', ''),
+            'test-content/parallel.md': ('parallel.md', ''),
             'test-content/test.txt': ('test.txt', ''),
             'another-content/test.md': ('test.md', 'another'),
             'test-content/nested/content.md': ('content.md', 'nested'),
@@ -244,7 +245,9 @@ class TestSync(unittest.TestCase):
             "notthere.txt",
             "../another-content/test.md",
             "./nested/content.md",
-            "./nested/example.yaml"
+            "./nested/example.yaml",
+            "./parallel.md",
+            "./parallel.md#with-fragment"
         ]
 
         expected_results = [
@@ -255,7 +258,9 @@ class TestSync(unittest.TestCase):
             "https://foo.bar/test-content/notthere.txt",
             "/docs/foo/another/test/",
             "/docs/foo/nested/content/",
-            "/docs/foo/nested/example.yaml"
+            "/docs/foo/nested/example.yaml",
+            "/docs/foo/parallel/",
+            "/docs/foo/parallel/#with-fragment"
         ]
 
         for case, expected in zip(cases, expected_results):
@@ -279,8 +284,8 @@ class TestSync(unittest.TestCase):
 
         cases = [
             "[exists-relative-link](./test.txt)",
-            "[exists-relative-link-index](./content.md)",
-            "[exists-relative-link-index](./else.md)",
+            "[exists-relative-link-index](./content.md)\nand\n[exists-relative-link-index](./content.md#with-fragment)",
+            "[else](else.md) and [else2](else.md)\nand\n[else-frag](./else.md#with-fragment) and [again](./else.md#with-another-fragment)",
             "[exists-relative-link-other-path](../some_other_folder/with_content.md)",
             "[exists-relative-link-fragment](test.txt#Fragment)",
             "[notfound-relative-link](./this/is/not/found.txt#FraGment)",
@@ -294,8 +299,8 @@ class TestSync(unittest.TestCase):
         ]
         expected_results = [
             "[exists-relative-link](/docs/test/test.txt)",
-            "[exists-relative-link-index](/docs/test/)",
-            "[exists-relative-link-index](/docs/test/else/)",
+            "[exists-relative-link-index](/docs/test/)\nand\n[exists-relative-link-index](/docs/test/#with-fragment)",
+            "[else](/docs/test/else) and [else](/docs/test/else/)\nand\n[else-frag](/docs/test/else/#with-fragment) and [again](/docs/test/else/#with-another-fragment)",
             "[exists-relative-link-other-path](/docs/test/else/)",
             "[exists-relative-link-fragment](/docs/test/test.txt#Fragment)",
             "[notfound-relative-link](http://test.com/tree/docs/test/this/is/not/found.txt#FraGment)",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When similar links are present in a single page, under certain
conditions links were rewritten twice, causing broken links.
Fix that by replacing (<original-link>) with parenthesys now.

Fixes #279

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
