### PR TITLE
Enable emoji for hugo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,6 +27,9 @@ pygmentsUseClassic = false
 # See https://help.farbox.com/pygments.html
 pygmentsStyle = "tango"
 
+# Enables emoji
+enableEmoji = true
+
 # Configure how URLs look like per section.
 [permalinks]
 blog = "/:section/:year/:month/:day/:slug/"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Hugo supports markdown emojis in the :<name>: format by they are
disabled by default. Enable them as might be used in Tekton docs.

Fixes #268

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
