### PR TITLE
Cleanup unused configs in sync.py

### DIFF
--- a/sync/README.md
+++ b/sync/README.md
@@ -57,12 +57,8 @@ The yaml sync file requires the following schema
 # The name of the component.
 # sync.py will use this value to build directories in content/ and vault/. This is used to for the list on the redenred web website.
 component: Foobar
-# The order of the component.
-displayOrder: 0
 # The GitHub repository where documentation resides.
 repository: https://github.com/tektoncd/foobar
-# The directory in the GitHub repository where contents reside.
-docDirectory: docs
 # The link to the GitHub tag page.
 archive: https://github.com/tektoncd/foobar/tags
 # The tags (versions) of contents to sync.

--- a/sync/config/README.md
+++ b/sync/config/README.md
@@ -9,13 +9,9 @@ The configuration is structure as follows:
 # The name of the component.
 # sync.py will use this value to build directories in content/ and vault/.
 component: <Component>
-# The order of the component in the documentation.
-displayOrder: 0
 # The GitHub repository where documentation resides.
 repository: https://github.com/tektoncd/<component>
 # The directory in the GitHub repository where contents reside.
-docDirectory: docs
-# The link to the GitHub tag page.
 archive: https://github.com/tektoncd/<component>/tags
 # The tags (versions) of contents to sync.
 # Note that sync.py and related script reads tags in the order specified in

--- a/sync/config/cli.yaml
+++ b/sync/config/cli.yaml
@@ -6,13 +6,9 @@
 # The name of the component.
 # sync.py will use this value to build directories in content/ and vault/.
 component: CLI
-# The order of the component.
-displayOrder: 2
 # The GitHub repository where documentation resides.
 repository: https://github.com/tektoncd/cli
 # The directory in the GitHub repository where contents reside.
-docDirectory: docs
-# The link to the GitHub tag page.
 archive: https://github.com/tektoncd/cli/tags
 # The tags (versions) of contents to sync.
 # Note that sync.py and related script reads tags in the order specified in
@@ -23,7 +19,7 @@ archive: https://github.com/tektoncd/cli/tags
 #   displayName: vX.Y.Z
 #   folders:
 #     docs:
-#       target: '/'            # optional, default value '/'
+#       target: ''             # optional, default value ''
 #       index: README.md       # optional, if _index.md exists
 #       include: ['*.md']      # optional, default value ['*']
 #       exclude: ['not_in.md'] # optional, default value []

--- a/sync/config/operator.yaml
+++ b/sync/config/operator.yaml
@@ -6,12 +6,8 @@
 # The name of the component.
 # sync.py will use this value to build directories in content/ and vault/.
 component: Operator
-# The order of the component.
-displayOrder: 4
 # The GitHub repository where documentation resides.
 repository: https://github.com/tektoncd/operator
-# The directory in the GitHub repository where contents reside.
-docDirectory: docs
 # The link to the GitHub tag page.
 archive: https://github.com/tektoncd/operator/tags
 # The tags (versions) of contents to sync.
@@ -23,7 +19,7 @@ archive: https://github.com/tektoncd/operator/tags
 #   displayName: vX.Y.Z
 #   folders:
 #     docs:
-#       target: '/'            # optional, default value '/'
+#       target: ''             # optional, default value ''
 #       index: README.md       # optional, if _index.md exists
 #       include: ['*.md']      # optional, default value ['*']
 #       exclude: ['not_in.md'] # optional, default value []

--- a/sync/config/pipelines.yaml
+++ b/sync/config/pipelines.yaml
@@ -6,12 +6,8 @@
 # The name of the component.
 # sync.py will use this value to build directories in content/ and vault/.
 component: Pipelines
-# The order of the component.
-displayOrder: 0
 # The GitHub repository where documentation resides.
 repository: https://github.com/tektoncd/pipeline
-# The directory in the GitHub repository where contents reside.
-docDirectory: docs
 # The link to the GitHub tag page.
 archive: https://github.com/tektoncd/pipeline/tags
 # The tags (versions) of contents to sync.
@@ -23,7 +19,7 @@ archive: https://github.com/tektoncd/pipeline/tags
 #   displayName: vX.Y.Z
 #   folders:
 #     docs:
-#       target: '/'            # optional, default value '/'
+#       target: ''             # optional, default value ''
 #       index: README.md       # optional, if _index.md exists
 #       include: ['*.md']      # optional, default value ['*']
 #       exclude: ['not_in.md'] # optional, default value []

--- a/sync/config/triggers.yaml
+++ b/sync/config/triggers.yaml
@@ -6,12 +6,8 @@
 # The name of the component.
 # sync.py will use this value to build directories in content/ and vault/.
 component: Triggers
-# The order of the component.
-displayOrder: 1
 # The GitHub repository where documentation resides.
 repository: https://github.com/tektoncd/triggers
-# The directory in the GitHub repository where contents reside.
-docDirectory: docs
 # The link to the GitHub tag page.
 archive: https://github.com/tektoncd/triggers/tags
 # The tags (versions) of contents to sync.
@@ -23,7 +19,7 @@ archive: https://github.com/tektoncd/triggers/tags
 #   displayName: vX.Y.Z
 #   folders:
 #     docs:
-#       target: '/'            # optional, default value '/'
+#       target: ''             # optional, default value ''
 #       index: README.md       # optional, if _index.md exists
 #       include: ['*.md']      # optional, default value ['*']
 #       exclude: ['not_in.md'] # optional, default value []

--- a/sync/sync.py
+++ b/sync/sync.py
@@ -363,7 +363,7 @@ def get_files_in_path(path, file_type):
 
 
 def load_config(files):
-    """ return a list of yaml files sorted based on a field called displayOrder """
+    """ return a list of yaml files"""
     yaml = YAML()
     dic_list = []
 
@@ -374,8 +374,6 @@ def load_config(files):
                 "filename": file,
                 "content": yaml.load(text)
             })
-
-    dic_list.sort(key=lambda x: x['content']['displayOrder'])
 
     return dic_list
 

--- a/sync/test_sync.py
+++ b/sync/test_sync.py
@@ -161,20 +161,20 @@ class TestSync(unittest.TestCase):
     def test_load_save_config(self):
         """ convert a list of files into a list of dictionaries """
         # create a tmp file with yaml txt
-        text = "{displayOrder: 1}"
+        text = "{repository: foo}"
 
         with tempfile.NamedTemporaryFile(dir='/tmp', delete=False) as tmp:
             tmp_name = tmp.name
             tmp.write(text.strip().encode())
 
-        expected = [{'content': {'displayOrder': 1},
+        expected = [{'content': {'repository': "foo"},
                      'filename': tmp_name}]
         actual = load_config([tmp_name])
         self.assertEqual(actual, expected)
 
         mod_config = actual
-        mod_config[0]['content']['displayOrder'] = 2
-        expected = [{'content': {'displayOrder': 2},
+        mod_config[0]['content']['repository'] = "bar"
+        expected = [{'content': {'repository': "bar"},
                      'filename': tmp_name}]
         save_config(mod_config)
         actual = load_config([tmp_name])
@@ -440,7 +440,6 @@ class TestSync(unittest.TestCase):
         test_component = {
             'component': 'test',
             'repository': 'http://test.com/test',
-            'docDirectory': 'docs',
             'tags': [{
                 'name': self.tagname,
                 'displayName': self.tagname,

--- a/sync/test_versions.py
+++ b/sync/test_versions.py
@@ -27,9 +27,7 @@ import versions
 test_config_string = """
 # This is a test config
 component: test
-displayOrder: 0
 repository: https://foo.bar/org/test
-docDirectory: docs
 archive: https://foo.bar/tags
 tags:
 - name: foo
@@ -47,9 +45,7 @@ tags:
 test_config2_string = """
 # This is a test config
 component: test2
-displayOrder: 1
 repository: https://foo.bar/org/test2
-docDirectory: docs
 archive: https://foo.bar/tags2
 tags:
 - name: foo
@@ -62,9 +58,7 @@ tags:
 test_config_string_new = """
 # This is a test config
 component: test
-displayOrder: 0
 repository: https://foo.bar/org/test
-docDirectory: docs
 archive: https://foo.bar/tags
 tags:
 - name: new


### PR DESCRIPTION
# Changes

displayOrder and docDirectory are not used anymore by the sync
script, so remove them from config, docs and tests.

The default target is now "" and not "/" anymore, so fix a few
comments where it referred to the old value.

Fixes: #323 312

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
