### PR TITLE
Fix Katacoda scenario Using Tekton Tasks

### DIFF
--- a/tutorials/katacoda/tasks/builders.md
+++ b/tutorials/katacoda/tasks/builders.md
@@ -17,7 +17,7 @@ specs:
       # The builder image to use
       # Here you will use the official Python image from DockerHub (https://hub.docker.com/_/python)
       # which includes the pytest framework
-      image: python
+      image: python:3.9
       # The command to run with the builder image
       # Here you will run the bash shell to start the Python interpreter
 			script: |

--- a/tutorials/katacoda/tasks/src/tekton-katacoda/tasks/task.yaml
+++ b/tutorials/katacoda/tasks/src/tekton-katacoda/tasks/task.yaml
@@ -9,7 +9,7 @@ spec:
       type: git
   steps:
   - name: pytest
-    image: python
+    image: python:3.9
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
# Changes
Fix Katacoda scenario Using Tekton Tasks: https://github.com/tektoncd/website/issues/347

The version of `pytest` specified in `dev_requirements.txt` is incompatible with Python 3.10. This remedy uses a fixed container image version for Python. In order to make the Katacoda experience as reproducible as possible, it’s a good practice to use fixed versions for as many things as possible anyway.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
