### PR TITLE
Issue 352 - Katacoda scenario Tekton Basic Pipeline - Textual improvements

### DIFF
--- a/tutorials/katacoda/basic-pipeline/step1.md
+++ b/tutorials/katacoda/basic-pipeline/step1.md
@@ -70,5 +70,7 @@ tkn taskrun logs --last -f
 It may take a few moments before your Task completes. When it executes, it should show the following output:
 
 ```console
+[hello] + set -e
+[hello] + echo Hello World!
 [hello] Hello World!
 ```

--- a/tutorials/katacoda/basic-pipeline/step1.md
+++ b/tutorials/katacoda/basic-pipeline/step1.md
@@ -13,9 +13,11 @@ spec:
   steps:
     - name: hello
       image: ubuntu
-      script: |
-        set -e
-        echo "Hello World!"
+      command:
+      - bash
+      - -c
+      args:
+      - echo "Hello World!"
 ```{{copy}}
 
 Write the YAML above to a file named task-hello.yaml, and apply it to your Kubernetes cluster:
@@ -70,7 +72,5 @@ tkn taskrun logs --last -f
 It may take a few moments before your Task completes. When it executes, it should show the following output:
 
 ```console
-[hello] + set -e
-[hello] + echo Hello World!
 [hello] Hello World!
 ```

--- a/tutorials/katacoda/basic-pipeline/step1.md
+++ b/tutorials/katacoda/basic-pipeline/step1.md
@@ -13,11 +13,9 @@ spec:
   steps:
     - name: hello
       image: ubuntu
-      command:
-      - bash
-      - -c
-      args:
-      - echo "Hello World!"
+      script: |
+        #!/usr/bin/env bash
+        echo "Hello World!"
 ```{{copy}}
 
 Write the YAML above to a file named task-hello.yaml, and apply it to your Kubernetes cluster:

--- a/tutorials/katacoda/basic-pipeline/step2.md
+++ b/tutorials/katacoda/basic-pipeline/step2.md
@@ -1,6 +1,6 @@
-In this section, we will build upon the first task we created and create
-a second task and verify it. It may seem repeatitive, but this is just an
-example. (after you're done just imagine what you could do!)
+In this section, we will build upon the first task we created, create
+a second task and verify it. It may seem repetitive, but this is just an
+example (after you're done just imagine what else you could do!).
 
 ## Extending your first CI/CD Workflow with a second Task and a Pipeline
 

--- a/tutorials/katacoda/basic-pipeline/step2.md
+++ b/tutorials/katacoda/basic-pipeline/step2.md
@@ -85,5 +85,7 @@ It may take a few moments before your `Task` completes. When it executes, it sho
 show the following output:
 
 ```console
+[goodbye] + set -e
+[goodbye] + echo Goodbye World!
 [goodbye] Goodbye World!
 ```

--- a/tutorials/katacoda/basic-pipeline/step2.md
+++ b/tutorials/katacoda/basic-pipeline/step2.md
@@ -24,11 +24,9 @@ spec:
   steps:
     - name: goodbye
       image: ubuntu
-      command:
-      - bash
-      - -c
-      args:
-      - echo "Goodbye World!"
+      script: |
+        #!/usr/bin/env bash
+        echo "Goodbye World!"
 ```{{copy}}
 
 Write the YAML above to a file named `task-goodbye.yaml`, and apply it to your Kubernetes cluster:

--- a/tutorials/katacoda/basic-pipeline/step2.md
+++ b/tutorials/katacoda/basic-pipeline/step2.md
@@ -24,9 +24,11 @@ spec:
   steps:
     - name: goodbye
       image: ubuntu
-      script: |
-        set -e
-        echo "Goodbye World!"
+      command:
+      - bash
+      - -c
+      args:
+      - echo "Goodbye World!"
 ```{{copy}}
 
 Write the YAML above to a file named `task-goodbye.yaml`, and apply it to your Kubernetes cluster:
@@ -85,7 +87,5 @@ It may take a few moments before your `Task` completes. When it executes, it sho
 show the following output:
 
 ```console
-[goodbye] + set -e
-[goodbye] + echo Goodbye World!
 [goodbye] Goodbye World!
 ```

--- a/tutorials/katacoda/basic-pipeline/step3.md
+++ b/tutorials/katacoda/basic-pipeline/step3.md
@@ -77,10 +77,6 @@ show the following output:
 
 ```console
 [hello : hello] Hello World!
-[hello : hello] + set -e
-[hello : hello] + echo Hello World!
 
 [goodbye : goodbye] Goodbye World!
-[goodbye : goodbye] + set -e
-[goodbye : goodbye] + echo Goodbye World!
 ```


### PR DESCRIPTION
# Changes

https://github.com/tektoncd/website/issues/352

Some textual improvements for Katacoda scenario “Tekton Basic Pipeline”. Fixed a typo and changed the YAML that we are instructed to copy to match the “reference” output shown in steps 1 and 2. Accordingly, changed the “reference” output shown in step 3 to match.

The rationale is that the output is now what one would expect in the first place (and becomes 100% predictable; with the script being echoed to the output, the order of that and the actual output of the `echo` command would differ between executions).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
