### PR TITLE
Add the last four pipeline releases

### DIFF
--- a/sync/config/pipelines.yaml
+++ b/sync/config/pipelines.yaml
@@ -26,6 +26,46 @@ archive: https://github.com/tektoncd/pipeline/tags
 #       header: <dict>         # optional, no header added if not set
 #         See https://www.docsy.dev/docs/adding-content/navigation/#section-menu
 tags:
+- name: release-v0.33.x
+  displayName: v0.33.x
+  # Dict of folders to sync
+  folders:
+    docs:
+      index: README.md
+      include: ['*.md']
+      exclude:
+      - api-spec.md
+      - tutorial.md
+- name: release-v0.32.x
+  displayName: v0.32.x
+  # Dict of folders to sync
+  folders:
+    docs:
+      index: README.md
+      include: ['*.md']
+      exclude:
+      - api-spec.md
+      - tutorial.md
+- name: release-v0.31.x
+  displayName: v0.31.x
+  # Dict of folders to sync
+  folders:
+    docs:
+      index: README.md
+      include: ['*.md']
+      exclude:
+      - api-spec.md
+      - tutorial.md
+- name: release-v0.30.x
+  displayName: v0.30.x
+  # Dict of folders to sync
+  folders:
+    docs:
+      index: README.md
+      include: ['*.md']
+      exclude:
+      - api-spec.md
+      - tutorial.md
 - name: release-v0.29.x
   displayName: v0.29.0
   # Dict of folders to sync


### PR DESCRIPTION
# Changes

Pipeline v0.33.0 was released today.
Add the docs for the last four versions of pipeline - it was not updated
since v0.29.x.

Using v0.33.x as display name so that we don't need to update the sync
config on minor releases.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
