### PR TITLE
Update hugo version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "make production-build"
 
 [build.environment]
-  HUGO_VERSION = "0.53"
+  HUGO_VERSION = "0.94.2"
 
 [context.production.environment]
   HUGO_ENV = "production"


### PR DESCRIPTION
Currently the netlify deploy uses hugo v0.53, which is almost 4 years
old and has some big inconsistencies when rendering markdown. This bumps
hugo up to the latest release, v0.94.2

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
