### PR TITLE
Add installation instructions to website

### DIFF
--- a/content/en/docs/Concepts/_index.md
+++ b/content/en/docs/Concepts/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Concepts"
 linkTitle: "Concepts"
-weight: 2
+weight: 3
 description: >
   Conceptual and technical information about Tekton
 ---

--- a/content/en/docs/Getting Started/pipelines.md
+++ b/content/en/docs/Getting Started/pipelines.md
@@ -1,29 +1,31 @@
+<!--
 ---
 title: "Getting Started with Pipelines"
 linkTitle: "Getting Started with Pipelines"
 weight: 2
 description: >
   Create and run your first Tekton pipeline
-
 ---
+-->
 
 This tutorial shows you how to:
 
-- Create two tasks.
-- Create a pipeline containing your tasks.
-- Use `PipelineRun` to instantiate and run the pipeline containing your tasks.
+1.  Create two tasks.
+1.  Create a pipeline containing your tasks.
+1.  Use `PipelineRun` to instantiate and run the pipeline containing your tasks.
 
 For this tutorial we are going to use [minikube][minikube] to run the commands
 locally.
 
 ## Prerequisites
 
-- Complete the [Getting started with tasks](/docs/getting-started/tasks/)
-  tutorial. *Do not clean up your resources*, skip the last section.
+1.  Complete the [Getting started with tasks](/docs/getting-started/tasks/)
+    tutorial. *Do not clean up your resources*, skip the last section.
 
-- [Install the Tekton CLI](/docs/cli/).
+1.  [Install the Tekton CLI](/docs/installation/tkn-cli/), which provides `tkn`
+    command.
 
-## Creating and running a second task
+## Create and run a second task
 
 You already have a *Hello World!* task. To create a second *Goodbye World!*
 task:
@@ -54,7 +56,7 @@ task:
 When a task is part of a pipeline you don't have to instantiate it, the pipeline
 is going to take care of that.
 
-## Creating and running a pipeline
+## Create and run a pipeline
 
 A **[pipeline](/docs/pipelines/pipelines/)** defines an ordered series of tasks
 arranged in a specific execution order as part of your CI/CD workflow.

--- a/content/en/docs/Getting Started/tasks.md
+++ b/content/en/docs/Getting Started/tasks.md
@@ -1,3 +1,4 @@
+<!--
 ---
 title: "Getting started with Tasks"
 likTitle: "Tasks"
@@ -5,6 +6,7 @@ weight: 1
 description: >
   Set up and run your first Tekton task
 ---
+-->
 
 This tutorial shows you how to 
 

--- a/content/en/docs/Installation/_index.md
+++ b/content/en/docs/Installation/_index.md
@@ -1,0 +1,15 @@
+<!--
+---
+title: "Installation"
+linkTitle: "Installation"
+weight: 2
+description: >
+  Install Tekton components on you cluster
+---
+-->
+
+This section provides instructions to install different Tekton components on
+your cluster. To proceed with the installation you must already have a cluster
+with the correct permissions and [kubectl] installed and configured.
+
+[kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl

--- a/content/en/docs/Installation/dashboard.md
+++ b/content/en/docs/Installation/dashboard.md
@@ -1,0 +1,315 @@
+<!--
+---
+title: "Install Tekton Dashboard"
+linkTitle: "Tekton Dashboard"
+weight: 4
+description: >
+  Install Tekton Dashboard on you cluster
+---
+-->
+
+## Prerequisites
+
+-   [Kubernetes] cluster version 1.18.0 or later.
+-   Admin privileges to the user running the installation.
+-   [Kubectl].
+-   [Tekton Pipelines](/docs/installation/pipelines/).
+-   [Tekton Triggers](/docs/installation/triggers/) (Optional).
+
+## Installation
+
+Every Tekton Dashboard version supports specific Tekton Pipelines and Tekton
+Triggers versions. Check [the compatibility table][compat-table] to find out
+which version of Tekton Dashboard works for your cluster.
+
+{{% tabs %}}
+
+{{% tab "Kubernetes" %}}
+
+1.  Depending on which version of Tekton Pipelines you want to install, run one
+    of the following commands:
+
+    -   **Latest official release**
+
+        ```bash
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases/dashboard/latest/tekton-dashboard-release.yaml
+        ```
+
+    -   **Specific Release**
+
+        ```bash
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases/dashboard/previous/VERSION_NUMBER/tekton-dashboard-release.yaml
+        ```
+
+        Replace `VERSION_NUMBER` with the numbered version you want to install.
+        For example, `v0.12.0`.
+
+    -   **Nightly release**
+
+        ```bash
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases-nightly/dashboard/latest/tekton-dashboard-release.yaml
+        ```
+
+1.  To monitor the installation, run:
+
+    ```bash
+    kubectl get pods --namespace tekton-pipelines --watch
+    ```
+
+    When all components show `Running` under the `STATUS` column the installation is
+    complete. Hit *Ctrl + C* to stop monitoring.
+
+{{% /tab %}}
+
+{{% tab "OpenShift" %}}
+
+1.  Depending on which version of Tekton Pipelines you want to install, run one
+    of the following commands:
+
+    -   **Latest official release**
+
+        ```bash
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases/dashboard/latest/openshift-tekton-dashboard-release.yaml \
+        --validate=false
+        ```
+
+    -   **Specific Release**
+
+        ```bash
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases/dashboard/previous/VERSION_NUMBER/openshift-tekton-dashboard-release.yaml \
+        --validate=false
+        ```
+
+        Replace `VERSION_NUMBER` with the numbered version you want to install.
+        For example, `v0.12.0`.
+
+1.  To monitor the installation, run:
+
+    ```bash
+    kubectl get pods --namespace tekton-pipelines --watch
+    ```
+
+    When all components show `Running` under the `STATUS` column the installation is
+    complete.
+
+{{% alert title="Note" color="info" %}}
+If you installed Tekton Pipelines and Triggers without using the OpenShift
+Pipelines operator, change the following args:
+
+- `--pipelines-namespace=openshift-pipelines`
+- `--triggers-namespace=openshift-pipelines`
+
+Set their values to the namespace where Pipelines and Triggers were respectively
+deployed.
+{{% /alert %}}
+
+{{% /tab %}}
+
+{{% /tabs %}}
+
+### Using the installer script
+
+Releases `v0.8.0` and later provide an installer script to simplify deploying
+Tekton Dashboard with custom options.
+
+For example, to install the latest release in read-only mode:
+
+```bash
+curl -sL https://raw.githubusercontent.com/tektoncd/dashboard/main/scripts/release-installer | \
+   bash -s -- install latest --read-only
+```
+
+See the developer documentation on [how to use the installer][installer-script]
+for more information.
+
+## Accessing the Dashboard
+
+By default, the Dashboard is not exposed outside the cluster.
+
+There are several solutions to access the Dashboard UI depending on your setup.
+
+### Using kubectl proxy
+
+The Dashboard can be accessed through its ClusterIP Service by running `kubectl
+proxy`.
+
+Assuming `tekton-pipelines` is the install namespace for the Dashboard, run the
+following command:
+
+```bash
+kubectl proxy
+```
+
+Browse
+http://localhost:8001/api/v1/namespaces/tekton-pipelines/services/tekton-dashboard:http/proxy/
+to access your Dashboard.
+
+### Using kubectl port-forward
+
+An alternative way to access the Dashboard is using `kubectl port-forward`.
+
+Assuming `tekton-pipelines` is the install namespace for the Dashboard, run the following command:
+
+```bash
+kubectl --namespace tekton-pipelines port-forward svc/tekton-dashboard 9097:9097
+```
+
+Browse http://localhost:9097 to access your Dashboard.
+
+### Using an Ingress rule
+
+A more advanced solution is to expose the Dashboard through an `Ingress` rule.
+This way the Dashboard can be accessed as a regular website without requiring
+`kubectl`.
+
+Assuming you have an [ingress controller][ingress-controller] up and running in
+your cluster, and that `tekton-pipelines` is the namespace where the Dashboard
+is installed, run the following command to create the `Ingress` resource:
+
+```bash
+# replace DASHBOARD_URL with the hostname you want for your dashboard
+# the hostname should be setup to point to your ingress controller
+DASHBOARD_URL=dashboard.domain.tld
+kubectl apply -n tekton-pipelines -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+spec:
+  rules:
+  - host: $DASHBOARD_URL
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: tekton-dashboard
+            port:
+              number: 9097
+EOF
+```
+
+You can now access the Dashboard UI at `http(s)://dashboard.domain.tld` in your
+browser (assuming the host configured in the ingress is `dashboard.domain.tld`)
+
+There are some additional considerations to keep in mind in this case:
+
+- The exact `Ingress` resource definition may vary depending on the ingress
+  controller installed in the cluster. Some specific annotations may be required
+  for the ingress controller to process the `Ingress` resource correctly.
+
+- If you don't have access to a domain you can use the freely available
+  [`nip.io`](https://nip.io/) service.
+
+The following example uses the NGINX ingress controller to expose the Dashboard
+on a specific path instead of at the root of the domain:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  rules:
+  - host: domain.tld
+    http:
+      paths:
+      - path: /tekton(/|$)(.*)
+        backend:
+          service:
+            name: tekton-dashboard
+            port:
+              number: 9097
+```
+
+You can then access the Dashboard UI at `http(s)://domain.tld/tekton/`.
+
+### Access control
+
+The Dashboard does not provide its own authentication or authorization, however
+it will pass on any authentication headers provided to it by a proxy deployed in
+front of the Dashboard. These are then handled by the Kubernetes API server
+allowing for full access control via [Kubernetes RBAC][k-rbac]. In case of
+forbidden access the Dashboard will display corresponding error notifications.
+
+See the walk-throughs for an example of [enabling authentication using
+oauth2-proxy][oauth2-wt].
+
+By default the Dashboard accesses resources and performs actions in the cluster
+using the permissions granted to its own ServiceAccount (the `tekton-dashboard`
+ServiceAccount in the `tekton-pipelines` namespace). If you wish to have the
+Dashboard perform actions on behalf of the authenticated user or some other
+ServiceAccount this can be achieved via [user impersonation][user-auth].  This
+is known to work with a number of popular solutions including oauth2-proxy,
+Keycloak, OpenUnison, Traefik, Istio's EnvoyFilter, and more.
+
+Typically, when configuring impersonation you would have the proxy forward its
+ServiceAccount token in the `Authorization` header, and details of the user and
+groups in the `Impersonate-User` and `Impersonate-Group` headers respectively.
+See the docs of your chosen solution for details.
+
+When using a reverse proxy, with impersonation headers or the user's account,
+you should remove the Dashboard's privileges to better maintain a "least
+privileged" approach.  This will make it less likely that the Dashboard's
+`ServiceAccount` will be abused:
+
+
+```
+kubectl delete clusterrolebinding -l rbac.dashboard.tekton.dev/subject=tekton-dashboard
+kubectl delete rolebinding -l rbac.dashboard.tekton.dev/subject=tekton-dashboard -n tekton-pipelines
+```
+
+If you're using one of these proxies to provide authentication but still want to
+use the Dashboard's ServiceAccount to access the Kubernetes APIs you may need to
+modify the proxy config to prevent it from sending the `Authorization` header on
+upstream requests to the Dashboard. Some examples of relevant config:
+
+- [oauth2-proxy]: add the `--pass-authorization-header=false` command line
+  argument or its equivalent to your config.
+
+- [Istio EnvoyFilter][istio-filter]: the external authentication service should
+  return a custom header `x-envoy-auth-headers-to-remove: Authorization`.
+
+- [Traefik]: `removeHeader: true`
+
+## Uninstalling the Dashboard on Kubernetes
+
+The Dashboard can be uninstalled by running the following command:
+
+```bash
+kubectl delete --filename \
+https://storage.googleapis.com/tekton-releases/dashboard/latest/tekton-dashboard-release.yaml
+```
+
+Use the URL corresponding to your installation.
+
+## Further reading
+
+To get started with Tekton Dashboard, see the [tutorial].
+
+To add more functionality to your Tekton Dashboard, see the [Tekton Dashboard
+extensions][dashboard-extensions].
+
+[kubernetes]: https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/
+[kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[compat-table]: https://github.com/tektoncd/dashboard/blob/main/README.md#which-version-should-i-use
+[installer-script]: https://github.com/tektoncd/dashboard/blob/main/docs/dev/installer.md
+[ingress-controller]: https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/
+[k-rbac]:https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+[oauth2-wt]: https://github.com/tektoncd/dashboard/tree/main/docs/walkthrough
+[user-auth]:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation
+[oauth2-proxy]: https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#command-line-options
+[istio-filter]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto
+[traefik]: https://doc.traefik.io/traefik/v2.0/middlewares/basicauth/#removeheader
+[tutorial]: https://github.com/tektoncd/dashboard/tree/main/docs/tutorial
+[dashboard-extensions]: https://github.com/tektoncd/dashboard/blob/main/docs/extensions.md 

--- a/content/en/docs/Installation/local-installation.md
+++ b/content/en/docs/Installation/local-installation.md
@@ -1,0 +1,101 @@
+<!--
+---
+title: "Local installation"
+linkTitle: "Local installation"
+weight: 2
+description: >
+  Install Tekton components on your local computer.
+---
+-->
+
+If you are going to test Tekton locally on your computer, two possible
+alternatives for that are **minikube** and **kind**. The [Getting
+Started](/docs/getting-started/) guides show you how to run several simple
+examples using minikube.
+
+{{% tabs %}}
+
+{{% tab "Minikube" %}}
+
+1.  [Install minikube][minikube] on your computer.
+
+1.  [Install kubectl][kubectl] on your computer.
+
+1.  Create a cluster.
+
+    ```bash
+    minikube start
+    ```
+
+1.  Verify that the cluster is working correctly.
+
+    ```bash
+    kubectl cluster-info
+    ```
+
+The output confirms that Kubernetes is up and running:
+
+```
+Kubernetes control plane is running at https://127.0.0.1:39509
+CoreDNS is running at
+https://127.0.0.1:39509/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+
+To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
+```
+
+[minikube]: https://minikube.sigs.k8s.io/docs/start/
+[kubectl]: https://kind.sigs.k8s.io/docs/user/quick-start/#installation
+
+{{% /tab %}}
+
+{{% tab "Kind" %}}
+
+1.  [Install kind][kind] on your
+    computer.
+
+1.  [Install kubectl][kubectl]
+    on your computer.
+
+1.  Create a cluster.
+
+    ```bash
+    kind create cluster
+    ```
+
+1.  Verify that the cluster is working correctly.
+
+    ```bash
+    kubectl cluster-info
+    ```
+
+The output confirms that Kubernetes is up and running:
+
+```
+Kubernetes control plane is running at https://127.0.0.1:39509
+CoreDNS is running at
+https://127.0.0.1:39509/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+
+To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
+```
+[kind]: https://kind.sigs.k8s.io/docs/user/quick-start/
+[kubectl]: https://kind.sigs.k8s.io/docs/user/quick-start/#installation
+
+{{% /tab %}}
+
+{{% /tabs %}}
+
+After you have a local cluster up and running, follow the instructions in the
+corresponding installation guide for each component.
+
+## Further reading
+
+-   [Getting started with Tasks][tasks-intro]
+
+Other resources
+
+-   [Set up a local Development environment with Minikube or Kind][local-setup]
+-   [Convenience scripts to run Kind][kind-setup]
+
+[kind-setup]: https://github.com/tektoncd/plumbing/tree/main/hack
+[local-setup]: https://github.com/tektoncd/pipeline/blob/main/docs/developers/local-setup.md
+[tasks-intro]: /docs/getting-started/tasks/

--- a/content/en/docs/Installation/pipelines.md
+++ b/content/en/docs/Installation/pipelines.md
@@ -1,0 +1,123 @@
+<!--
+---
+title: "Install Tekton Pipelines"
+linkTitle: "Tekton Pipelines"
+weight: 2
+description: >
+  Install Tekton Pipelines on you cluster
+---
+-->
+
+## Prerequisites
+
+-   [Kubernetes] cluster version 1.21 or later.
+-   Admin privileges to the user running the installation.
+-   [Kubectl].
+
+## Installation
+
+To install Tekton Pipelines on your cluster.
+{{% tabs %}}
+
+{{% tab "Kubernetes" %}}
+
+1.  Depending on which version of Tekton Pipelines you want to install, run one
+    of the following commands:
+
+    -   **Latest official release**
+
+        ```bash
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+        ```
+
+    -   **Nightly release**
+
+        ```bash
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases-nightly/pipeline/latest/release.yaml
+        ```
+
+    -   **Specific Release**
+
+        ```bash
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases/pipeline/previous/VERSION_NUMBER/release.yaml
+        ```
+
+        Replace `VERSION_NUMBER` with the numbered version you want to install.
+        For example, `v0.31.4`.
+
+    -   **Untagged Release**
+
+        If your container runtime does not support `image-reference:tag@digest` (for
+        example, `cri-o` used in OpenShift 4.x):
+
+        ```bash
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases/pipeline/latest/release.notags.yaml
+        ```
+
+1.  To monitor the installation, run:
+
+    ```bash
+    kubectl get pods --namespace tekton-pipelines --watch
+    ```
+
+    When all components show `Running` under the `STATUS` column the installation is
+    complete. Hit *Ctrl + C* to stop monitoring.
+
+{{% alert title="Note" color="info" %}}
+*Some cloud providers, such as GKE, may require that you open the port 8443 in
+the firewall rules so that the Tekton Pipelines webhook is reachable.*
+{{% /alert %}}
+
+{{% /tab %}}
+
+{{% tab "OpenShift" %}}
+
+1.  Log on as a user with the  `cluster-admin` privileges. The following example
+    uses the default `system:admin` user:
+
+    ```bash
+    oc login -u system:admin
+    ```
+
+1.  Set up the namespace (project) and configure the service account:
+
+    ```bash
+    oc new-project tekton-pipelines
+    oc adm policy add-scc-to-user anyuid -z tekton-pipelines-controller
+    oc adm policy add-scc-to-user anyuid -z tekton-pipelines-webhook
+    ```
+1.  Install Tekton pipelines
+
+    ```bash
+    oc apply --filename \
+    https://storage.googleapis.com/tekton-releases/pipeline/latest/release.notags.yaml
+    ```
+
+1.  To monitor the installation, run:
+
+    ```bash
+    kubectl get pods --namespace tekton-pipelines --watch
+    ```
+
+    When all components show `Running` under the `STATUS` column the installation is
+    complete.
+
+See the [OpenShift CLI][openshift] documentation for more information about the
+`oc` command.
+
+[openshift]: https://docs.openshift.com/container-platform/latest/welcome/index.html
+{{% /tab %}}
+
+{{% /tabs %}}
+
+## Further reading
+
+See the [Pipelines repository documentation](/docs/pipelines/install/) for more
+installation and configuration options.
+
+[kubernetes]: https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/
+[kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl

--- a/content/en/docs/Installation/tkn-cli.md
+++ b/content/en/docs/Installation/tkn-cli.md
@@ -1,0 +1,183 @@
+<!--
+---
+title: "Install the Tekton CLI"
+linkTitle: "Tekton CLI"
+weight: 4
+description: >
+  Install `tkn`, the Tekton CLI
+---
+-->
+
+The Tekton CLI, `tkn`, provides easy interaction with the Tekton components. The
+CLI is available on all major platforms. You can also build it from source or
+set it up as a kubectl plugin.
+
+## Prerequisites
+
+To install `tkn` using a package manager:
+
+- MacOS: [Homebrew].
+
+- Windows:  [Chocolatey].
+
+- Linux: APT or DNF for deb-based or rpm-based distributions, respectively.  
+
+[homebrew]: https://brew.sh/
+[chocolatey]: https://chocolatey.org/ 
+
+## Installation
+
+{{% tabs %}}
+
+{{% tab "macOS" %}}
+
+- **[Homebrew][homebrew-formula] installation**
+
+  ```bash
+  brew install tektoncd-cli
+  ```
+
+- **Manual installation**
+
+  Download the tarball from the [releases page][tkn-release]. After
+  downloading the file, extract it to a directory in your `PATH`. For example,
+  to install the version `0.23.1` for a `x86-64` mac:
+
+  ```bash
+  curl -LO https://github.com/tektoncd/cli/releases/download/v0.23.1/tkn_0.23.1_Darwin_x86_64.tar.gz
+  sudo tar -xvzf tkn_0.23.1_Darwin_x86_64.tar.gz -C /usr/local/bin/ tkn
+  ```
+
+[homebrew-formula]: https://formulae.brew.sh/formula/tektoncd-cli
+[tkn-release]: https://github.com/tektoncd/cli/releases
+
+{{% /tab %}}
+
+{{% tab "Windows" %}}
+
+- **Chocolatey installation**
+
+  ```cmd
+  choco install tektoncd-cli --confirm
+  ```
+
+- **Manual installation**
+
+  Download the `.zip` file from the [`tkn` Releases page][tkn-release].
+  After downloading the file, add it to your `Path`:
+
+  1.  Uncompress the `.zip` file.
+  1.  Open **Control Panel** > **System and Security** > **System** > **Advanced System Settings**.
+  1.  Click **Environment Variables**, select the `Path` variable and click **Edit**.
+  1.  Click **New** and add the path to your uncompressed file.
+  1.  Click **OK**.
+
+[tkn-release]: https://github.com/tektoncd/cli/releases
+
+{{% /tab %}}
+
+{{% tab "Linux" %}}
+
+-   **Debian, Ubuntu, and other deb-based distros**
+
+    - Using the system package manager:
+   
+      ```bash
+      sudo apt update;sudo apt install -y gnupg
+      sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3EFE0E0A2F2F60AA
+      echo "deb http://ppa.launchpad.net/tektoncd/cli/ubuntu eoan main"|sudo tee /etc/apt/sources.list.d/tektoncd-ubuntu-cli.list
+      sudo apt update && sudo apt install -y tektoncd-cli
+      ```
+
+    - Manual installation:
+
+      You can use `curl` to download and install a particular version from
+      [releases page][tkn-release]. For example, the version `0.23.1` for
+      `x86-64`:
+
+      ```bash
+      curl -LO https://github.com/tektoncd/cli/releases/download/v0.23.1/tektoncd-cli-0.23.1_Linux-64bit.deb
+      sudo dpkg -i tektoncd-cli-0.23.1_Linux-64bit.deb
+      ```
+
+-   **Fedora, CentOS, and other rpm-based distros**
+
+    - Using the system package manager, there's an unofficial repository you can use:
+
+      ```bash
+      dnf copr enable chmouel/tektoncd-cli
+      dnf install tektoncd-cli
+      ```
+
+    - Manual installation:
+
+      You can use `curl` to download and install a particular version from
+      [releases page][tkn-release]. For example, the version `0.23.1` for
+      `x86-64`:
+
+      ```bash
+      curl -OL https://github.com/tektoncd/cli/releases/download/v0.23.1/tektoncd-cli-0.23.1_Linux-64bit.rpm
+      rpm -Uvh tektoncd-cli-0.23.1_Linux-64bit.rpm
+      ```
+
+-   **Other Linux distributions**
+
+    Find the tarball of the Tekton CLI release for the platform (`ARM` or
+    `X86-64`) you would like to install on the [releases page][tkn-release] and copy
+    the binary to a folder in your `PATH`. For example, to install version `0.23.1`
+    for `x86-64` in `/usr/local/bin`:
+
+    ```bash
+    curl -LO https://github.com/tektoncd/cli/releases/download/v0.23.1/tkn_0.23.1_Linux_arm64.tar.gz
+    sudo tar -xvzf tkn_0.23.1_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
+    ```
+
+[tkn-release]: https://github.com/tektoncd/cli/releases
+
+{{% /tab %}}
+
+{{% /tabs %}}
+
+### Build the binary from source
+
+To build `tkn` from the source, set up your [Go](https://golang.org/)
+development environment, clone the [GitHub repository for
+`tkn`](https://github.com/tektoncd/cli), and run the following commands in the
+cloned directory:
+
+```bash
+export GO111MODULE=on
+make bin/tkn
+```
+
+The `tkn` executable will be available at `/bin`.
+
+### Add as a `kubectl` plugin
+
+After you install `tkn`, to add it as a [`kubectl` plugin][kplugin] run the
+following command:
+
+```bash
+ln -s /usr/local/bin/tkn /usr/local/bin/kubectl-tkn
+```
+
+{{% alert title="Note" color="info" %}}
+*The previous command assumes that your `tkn` executable is available at
+`/usr/local/bin/tkn`. Adjust the path if your executable is at a different
+location.*
+{{% /alert %}}
+
+To verify that the plugin was successfully added:
+
+```bash
+kubectl plugin list
+```
+
+The output lists `kubectl-tkn` as one of the plugins.
+
+## Further reading
+
+See all supported commands and options in the [Tekton CLI reference documentation][tkn-ref]. 
+
+[kplugin]: https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/#using-a-plugin
+[tkn-ref]: https://github.com/tektoncd/cli/tree/main/docs/cmd

--- a/content/en/docs/Installation/triggers.md
+++ b/content/en/docs/Installation/triggers.md
@@ -1,0 +1,84 @@
+<!--
+---
+title: "Install Tekton Triggers"
+linkTitle: "Tekton Triggers"
+weight: 3
+description: >
+  Install Tekton Triggers on you cluster
+---
+-->
+
+## Prerequisites
+
+-   [Kubernetes] cluster version 1.18 or later.
+-   Admin privileges to the user running the installation.
+-   [Kubectl].
+-   [Tekton Pipelines](/docs/installation/pipelines/)
+
+## Installation
+
+1.  Log on to your Kubernetes cluster with the same user account that installed
+    Tekton Pipelines.
+
+1.  Depending on which version of Tekton Triggers you want to install, run one
+    of the following commands:
+
+    -   **Latest official release**
+
+        ```bash
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml
+        ```
+
+    -   **Nightly release**
+
+        ```bash
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases-nightly/triggers/latest/release.yaml
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases-nightly/triggers/latest/interceptors.yaml
+        ```
+
+    -   **Specific Release**
+
+        ```bash
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases/triggers/previous/VERSION_NUMBER/release.yaml
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases/triggers/previous/VERSION_NUMBER/interceptors.yaml
+        ```
+
+        Replace `VERSION_NUMBER` with the numbered version you want to install.
+        For example, `v0.19.1`.
+
+    -   **Untagged Release**
+
+        If your container runtime does not support `image-reference:tag@digest` (for
+        example, `cri-o` used in OpenShift 4.x):
+
+        ```bash
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases/triggers/latest/release.notags.yaml
+        kubectl apply --filename \
+        https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.notags.yaml
+        ```
+
+1.  To monitor the installation, run:
+
+    ```bash
+    kubectl get pods --namespace tekton-pipelines --watch
+    ```
+
+    When all components show `Running` under the `STATUS` column the installation is
+    complete. Hit *Ctrl + C* to stop monitoring.
+
+## Further reading
+
+See the [Triggers reference documentation][triggers] to learn more about usage
+and configuration options.
+
+[kubernetes]: https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/
+[kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
+[triggers]: /docs/triggers/


### PR DESCRIPTION
# Changes

This adds the installation instructions to the website under the same
section, for visibility and ease of navigation. There's no new
information from what you can find on the repo docs for each component,
but the installation instructions are presented in a cohesive way,
following the same style and structure to provide a better experience
for the user.

This also fixes some minor formatting errors and updates links in the
"Getting started" tutorials.

/closes [#4553](https://github.com/tektoncd/pipeline/issues/4553)

[Docs Preview](https://deploy-preview-377--tekton.netlify.app/docs/installation/)

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
