### PR TITLE
Update netlify dev to avoid framework prompt

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,6 +17,7 @@
 
 [dev]
   command = "make serve URL=http://localhost:8888/"
+  framework = "hugo"
 
 [[plugins]]
 package = "netlify-plugin-checklinks"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update the dev section as recommended by `netlify dev` to avoid
the framework selection prompt on startup. Without this the command
hangs waiting for user input. See output from netlify CLI that
suggested the change:

```
$ netlify dev
◈ Netlify Dev ◈
◈ Injected netlify.toml file env var: HUGO_VERSION
◈ Ignored general context env var: LANG (defined in process)
◈ Ignored general context env var: LC_ALL (defined in process)
? Multiple possible start commands found Hugo-hugo server -w
Add 'framework = "hugo"' to the [dev] section of your netlify.toml to avoid this selection prompt next time
◈ Starting Netlify Dev with Hugo
hugo server \
        --baseURL http://localhost:8888/ \
        --buildDrafts \
        --buildFuture \
        --disableFastRender \
        --ignoreCache \
        --watch
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
