### PR TITLE
Update git-clone task instructions per 0.8

### DIFF
--- a/content/en/docs/How-to guides/kaniko-build-push.md
+++ b/content/en/docs/How-to guides/kaniko-build-push.md
@@ -85,6 +85,9 @@ metadata:
 spec:
   pipelineRef:
     name: clone-build-push
+  podTemplate:
+    securityContext:
+      fsGroup: 65532
   workspaces:
   - name: shared-data
     volumeClaimTemplate:
@@ -382,6 +385,9 @@ metadata:
 spec:
   pipelineRef:
     name: clone-build-push
+  podTemplate:
+    securityContext:
+      fsGroup: 65532
   workspaces:
   - name: shared-data
     volumeClaimTemplate:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Recently, the git-clone task was updated to version 0.8 which is not
backwards compatible in that it is run as a non-root user which does not
have access to volumes mounted via workspaces by default. To accomodate
this change, the users need to update their PipelineRuns and TaskRuns
with `podTemplate.securityContext.fsGroup = 65532` to fix the
permissions on mounted volumes.

This commit makes this configuration change in the how-to guide.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
