### PR TITLE
Comment out synced files front matter

### DIFF
--- a/sync/sync.py
+++ b/sync/sync.py
@@ -52,6 +52,8 @@ jinja_env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
 
 FM_BOUNDARY = re.compile(r"^(?:<!--\n)?-{3,}\s*$(?:\n-->)?", re.MULTILINE)
 YAML_SEPARATOR = "---\n"
+FM_WRAPPER_OPEN = "<!--\n"
+FM_WRAPPER_CLOSE = "-->\n"
 
 FOLDER_INDEX = '_index.md'
 
@@ -226,9 +228,11 @@ def write_front_matter(target_doc, fm_doc, fm_config):
     fm_config = fm_config or {}
     fm_doc.update(fm_config)
     if fm_doc:
+        target_doc.write(FM_WRAPPER_OPEN)
         target_doc.write(YAML_SEPARATOR)
         YAML().dump(fm_doc, target_doc)
         target_doc.write(YAML_SEPARATOR)
+        target_doc.write(FM_WRAPPER_CLOSE)
 
 def transform_links_doc(text, base_path, local_files, rewrite_path, rewrite_url):
     """ transform all the links the text """

--- a/sync/test_sync.py
+++ b/sync/test_sync.py
@@ -342,11 +342,13 @@ class TestSync(unittest.TestCase):
         with tempfile.TemporaryDirectory() as site_dir:
             expected_result = os.path.join(site_dir, 'target', 'target.md')
             expected_content = (
+                "<!--\n"
                 "---\n"
                 "test1: abc\n"
                 "test2: 1\n"
                 "test3: true\n"
                 "---\n"
+                "-->\n"
             )
             actual_result = transform_doc(
                 self.doc, 'test-content', 'target.md', 'target', header, {},
@@ -389,10 +391,12 @@ class TestSync(unittest.TestCase):
                 os.path.join(site_dir, 'target', 'test.txt')]
 
             template = (
+                "<!--\n"
                 "---\n"
                 "test1: abc\n"
                 "weight: {weight}\n"
                 "---\n"
+                "-->\n"
             )
             expected_contents = [template.format(weight=idx) for idx in range(2)]
             actual_results = transform_docs(
@@ -423,10 +427,12 @@ class TestSync(unittest.TestCase):
                 os.path.join(site_dir, 'target', 'test.txt')]
 
             template = (
+                "<!--\n"
                 "---\n"
                 "test1: abc\n"
                 "weight: {weight}\n"
                 "---\n"
+                "-->\n"
             )
             expected_contents = [template.format(weight=idx) for idx in range(2)]
             actual_results = transform_docs(


### PR DESCRIPTION
# Changes

Commenting out the front matter allows to reuse that content in other
files where it may be relevant using the `readfile` shortcode. This
doesn't affect the normal functionality of the YAML front matter.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
