### PR TITLE
Use generateName in pipelineruns

### DIFF
--- a/content/en/docs/How-to guides/clone-repository.md
+++ b/content/en/docs/How-to guides/clone-repository.md
@@ -131,14 +131,17 @@ together in the file.
     apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: clone-read-run
+      generateName: clone-read-run-
     spec:
       pipelineRef:
         name: clone-read
+      podTemplate:
+        securityContext:
+          fsGroup: 65532
     ```
 
-    This PipelineRun, `clone-read-run`, instantiates `clone-read`, as specified
-    by [the `pipelineRef` target][pipelineref] in the `spec` section.
+    This PipelineRun instantiates `clone-read`, as specified by [the
+    `pipelineRef` target][pipelineref] in the `spec` section.
 
 1.  Instantiate the Workspace:
   
@@ -347,16 +350,24 @@ Now you are ready to test the code.
     kubectl apply -f pipeline.yaml
     ```
 
-2.  Apply the PipelineRun:
+1.  Create the PipelineRun:
 
     ```bash
-    kubectl apply -f pipelinerun.yaml
+    kubectl create -f pipelinerun.yaml
     ```
 
-3.  Monitor the Pipeline execution:
+    This creates a PipelineRun with a unique name each time:
+
+    ```
+    pipelinerun.tekton.dev/clone-read-run-4kgjr created
+    ```
+
+
+1.  Use the PipelineRun name from the output of the previous step to monitor the
+    Pipeline execution:
 
     ```bash
-    tkn pipelinerun logs clone-read-run -f
+    tkn pipelinerun logs  clone-read-run-4kgjr -f
     ```
 
     You may have to wait a few seconds. The output confirms that the respository
@@ -451,10 +462,13 @@ The PipelineRun:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: clone-read-run
+  generateName: clone-read-run-
 spec:
   pipelineRef:
     name: clone-read
+  podTemplate:
+    securityContext:
+      fsGroup: 65532
   workspaces:
   - name: shared-data
     volumeClaimTemplate:

--- a/content/en/docs/How-to guides/kaniko-build-push.md
+++ b/content/en/docs/How-to guides/kaniko-build-push.md
@@ -81,7 +81,7 @@ Then create the corresponding `pipelinerun.yaml` file:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: clone-build-push-run
+  generateName: clone-build-push-run-
 spec:
   pipelineRef:
     name: clone-build-push
@@ -266,16 +266,23 @@ You are ready to install the Tasks and run the pipeline.
     kubectl apply -f pipeline.yaml
     ```
 
-1.  Apply the PipelineRun:
+1.  Create the PipelineRun:
 
     ```bash
-    kubectl apply -f pipelinerun.yaml
+    kubectl create -f pipelinerun.yaml
     ```
 
-1.  Monitor the Pipeline execution:
+    This creates a PipelineRun with a unique name each time:
+
+    ```
+    pipelinerun.tekton.dev/clone-build-push-run-4kgjr created
+    ```
+
+1.  Use the PipelineRun name from the output of the previous step to monitor the
+    Pipeline execution:
 
     ```bash
-    tkn pipelinerun logs clone-build-push-run -f
+    tkn pipelinerun logs  clone-build-push-run-4kgjr -f
     ```
 
     After a few seconds, the output confirms that the image was built and
@@ -381,7 +388,7 @@ The PipelineRun:
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: clone-build-push-run
+  generateName: clone-build-push-run-
 spec:
   pipelineRef:
     name: clone-build-push


### PR DESCRIPTION
# Changes

To avoid having to delete and reapply a Pipelinerun when developing your code, this PR switches to `generateName`, which adds a suffix to have a unique name each time.

Additionally, this PR also fixes a problem with the latest version of the `git-clone` Task in the Git clone tutorial.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
