### PR TITLE
Fix typo in kaniko-build-push.md

### DIFF
--- a/content/en/docs/How-to guides/kaniko-build-push.md
+++ b/content/en/docs/How-to guides/kaniko-build-push.md
@@ -46,7 +46,7 @@ this guide.
 
 ## Clone the repository
 
-Create a new Pipeline, `pipeline,yaml`, that uses the *git clone* Task to [clone
+Create a new Pipeline, `pipeline.yaml`, that uses the *git clone* Task to [clone
 the source code from a git repository][tekton-clone]:
 
 ```yaml


### PR DESCRIPTION
Fixing a small typo which breaks the How-to Guide if followed blindly/copy-pasted.

The documentation refers to `pipeline,yaml` in line 49, but I believe it should be referring to `pipeline.yaml` ( using a punctuation instead of a comma ).

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

```diff
- Create a new Pipeline, `pipeline,yaml`, that uses the *git clone* Task to [clone
+ Create a new Pipeline, `pipeline.yaml`, that uses the *git clone* Task to [clone
```

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
