### PR TITLE
wrong component name in docs

### DIFF
--- a/content/en/docs/Getting Started/triggers.md
+++ b/content/en/docs/Getting Started/triggers.md
@@ -66,7 +66,7 @@ when the EventListener detects an event.
     ```
 
     When `tekton-triggers-controller`, `tekton-triggers-webhook`, and
-    `tekton-triggers-core-controller` show `1/1` under the `READY` column, you
+    `tekton-triggers-core-interceptors` show `1/1` under the `READY` column, you
     are ready to continue. For example:
 
     ```


### PR DESCRIPTION
https://tekton.dev/docs/getting-started/triggers/#:~:text=tekton%2Dpipelines%20%2D%2Dwatch-,When%20tekton%2Dtriggers%2Dcontroller%2C%20tekton%2Dtriggers%2Dwebhook%2C%20and%20tekton%2Dtriggers%2Dcore%2Dcontroller%20show%201/1%20under%20the%20READY%20column%2C%20you%20are%20ready%20to%20continue.%20For%20example%3A,-NAME%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20READY%20%20%20STATUS

change "tekton-triggers-core-controller" to "tekton-triggers-core-interceptors"

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
