### PR TITLE
Add release selector to docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 resources/_gen/
 public/
 assets/js/version-switcher.js
+assets/js/release-switcher.js
 
 # IDEs
 .vscode

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -122,6 +122,12 @@ pre {
    }
 }
 
+/* Hide releases disclaimer by default, dinamically show it with js */
+
+#release-switcher { visibility: hidden }
+#nightly-release-li { visibility: hidden }
+#lts-release-li { visibility: hidden }
+
 /* Consistent borders around code blocks */
 
 pre { border: 1px solid $light;}

--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ params:
   ui:
     sidebar_menu_compact: false
     sidebar_menu_foldable: true
-    breadcrumb_disable: false
+    breadcrumb_disable: true
     sidebar_search_disable: false
     navbar_logo: true
     footer_about_disable: false

--- a/content/en/docs/Installation/pipelines.md
+++ b/content/en/docs/Installation/pipelines.md
@@ -8,7 +8,7 @@ description: >
 ---
 -->
 
-{{% readfile "/docs/Pipelines/install.md" %}}
+{{< readfile "/docs/Pipelines/install.md" >}}
 
 ---
 {{< card  >}}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -20,6 +20,9 @@
           </aside>
           <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
             {{ partial "version-banner.html" . }}
+			      {{ if strings.Contains .Page.RelPermalink "/docs/" -}}
+              {{ partial "release-selector.html" }}
+            {{ end -}}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             {{ block "main" . }}{{ end }}
           </main>

--- a/layouts/partials/release-selector.html
+++ b/layouts/partials/release-selector.html
@@ -1,0 +1,20 @@
+{{ $jsRelSwitcher := resources.Get "js/release-switcher.js" }}
+{{ $jsRelSwitcher := $jsRelSwitcher | fingerprint }}
+<script src="{{ $jsRelSwitcher.RelPermalink }}" integrity="{{ $jsRelSwitcher.Data.Integrity }}"></script>
+<nav class="td-breadcrumbs td-breadcrumbs__single" id="release-switcher">
+  <ol class="breadcrumb font-weight-bold">
+    <li id="latest-release-li" class="breadcrumb-item active">
+      Documentation for latest release
+    </li>
+
+    <li id="nightly-release-li" class="breadcrumb-item">
+      <a id="nightly-release-link" href="#">Go to Nightly Release</a>
+    </li>
+
+    <li id="lts-release-li" class="breadcrumb-item">
+      <a id="lts-release-link" href="#">Go to Latest LTS release</a>
+    </li>
+  </ol>
+  <script>findReleases()</script>
+</nav>
+

--- a/sync/config/pipelines.yaml
+++ b/sync/config/pipelines.yaml
@@ -394,8 +394,4 @@ tags:
       include: ['*.md']
       exclude:
       - api-spec.md
-      - deprecations.md
-      - install.md
-      - runs.md
-      - tekton-bundle-contracts.md
       - tutorial.md

--- a/sync/sync.py
+++ b/sync/sync.py
@@ -500,6 +500,8 @@ def sync(config_folder, update_cache):
     versions = get_versions(config)
     # create version switcher script
     create_resource(JS_ASSET_DIR, "version-switcher.js", versions)
+    # create release switcher script
+    create_resource(JS_ASSET_DIR, "release-switcher.js", versions)
     # create index for vault
     create_resource(VAULT_DIR, FOLDER_INDEX, versions)
 

--- a/templates/release-switcher.js.template
+++ b/templates/release-switcher.js.template
@@ -1,0 +1,62 @@
+if (typeof componentVersions === 'undefined') {
+  const componentVersions = JSON.parse('{{ component_versions_json }}');
+}
+
+const getComponentReleases = () => {
+  const pathName = window.location.pathname;
+  const componentVersionStr = pathName.split("/")[2];
+  const componentRawName = componentVersionStr.split("-")[0];
+  let latestVersion;
+  let nightlyVersion;
+  let latestLTS;
+  let componentName;
+
+  componentVersions.forEach((componentVersion) => {
+    if (componentVersion.name.toLowerCase() === componentRawName) {
+      componentName = componentVersion.name;
+      const versions = componentVersion.tags;
+      latestVersion = versions[0].displayName;
+      if (versions.length > 1) {
+        nightlyVersion = versions[versions.length - 1].displayName;
+      }
+      versions.forEach((version) => {
+        if (version.displayName.toLowerCase().includes('lts') && !latestLTS) {
+          latestLTS = version.displayName;
+        }
+      });
+    }
+  });
+  return {
+    name: componentName,
+    latest: latestVersion,
+    nightly: nightlyVersion,
+    lts: latestLTS,
+  };
+};
+
+const findReleases = () => {
+  const componentReleases = getComponentReleases();
+
+  const releasesNode = document.getElementById('release-switcher');
+  const latestNode = document.getElementById('latest-release-li');
+  const nightlyLiNode = document.getElementById('nightly-release-li');
+  const nightlyNode = document.getElementById('nightly-release-link');
+  const ltsLiNode = document.getElementById('lts-release-li');
+  const ltsNode = document.getElementById('lts-release-link');
+
+  if (componentReleases.name) {
+    let nightlyURL = `/vault/${componentReleases.name}-${componentReleases.nightly}`;
+    let ltsURL = `/vault/${componentReleases.name}-${componentReleases.lts}`;
+    releasesNode.style.visibility = 'visible';
+    latestNode.innerText = `Documentation for ${componentReleases.name}-${componentReleases.latest}`;
+    if (componentReleases.nightly) {
+      nightlyLiNode.style.visibility = 'visible';
+      nightlyNode.setAttribute('href', nightlyURL.toLowerCase());
+    }
+    if (componentReleases.lts) {
+      ltsLiNode.style.visibility = 'visible';
+      ltsURL = (componentReleases.lts == componentReleases.latest) ? '#' : ltsURL.toLowerCase();
+      ltsNode.setAttribute('href', ltsURL);
+    }
+  }
+};


### PR DESCRIPTION
# Changes

- Create new partial to display links to the Nightly (repo HEAD) and Latest LTS releases. As discussed on [Slack](https://tektoncd.slack.com/archives/CLCCEBUMU/p1675871079501169).
- Disable breadcrumb and use that space for the links. I'm trying to keep top of the doc uncluttered, I think the site is fairly flat, the left nav tree provides enough context to figure out your current location. Open to alternative suggestions.
- Fix delimiter in Pipelines Installation docs `readfile`.


|  **Preview with Nightly and LTS** |
| --- |
| ![Screenshot from 2023-02-23 13-46-45](https://user-images.githubusercontent.com/22261639/221014826-f260a18e-b2da-4c38-8b68-17b7c6693714.png) |
| **Preview with only Latest**  |
| ![Screenshot from 2023-02-23 13-47-30](https://user-images.githubusercontent.com/22261639/221014898-10659fc3-f5b0-4c73-8f42-e482129d1fd3.png) |
|  **Preview for docs outside components** |
| ![Screenshot from 2023-02-23 13-47-50](https://user-images.githubusercontent.com/22261639/221014988-5867ff65-3898-48de-9206-adcabd7e39b8.png) |

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
