### PR TITLE
Remove metadata.description from show-readme.yaml

### DIFF
--- a/content/en/docs/How-to-guides/clone-repository.md
+++ b/content/en/docs/How-to-guides/clone-repository.md
@@ -295,8 +295,8 @@ and the [examples folder][repo-examples] in the Pipelines git repository.
     kind: Task
     metadata:
       name: show-readme
-      description: Read and display README file.
     spec:
+      description: Read and display README file.
       workspaces:
       - name: source
       steps:
@@ -493,8 +493,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: show-readme
-  description: Read and display README file.
 spec:
+  description: Read and display README file.
   workspaces:
   - name: source
   steps:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

show-readme.yaml file contains description which causes following error since description under metadata is an unknown field, removing that line fixed the issue.

Failure:
```
kubectl apply -f show-readme.yaml
Error from server (BadRequest): error when creating "show-readme.yaml": Task in version "v1beta1" cannot be handled as a Task: strict decoding error: unknown field "metadata.description"
```
Success:

```
kubectl apply -f show-readme.yaml
task.tekton.dev/show-readme created
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
