### PR TITLE
Redirect /predicate/chains to Chains documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@ node_modules/
 
 # Generated content
 resources/_gen/
-public/
+public/**
+## Allow redirect file.
+!public/_redirects
 assets/js/version-switcher.js
 assets/js/release-switcher.js
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+# Chains predicate docs.
+/predicate/chains/* https://github.com/tektoncd/chains/tree/main/docs/predicate/:splat


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This sets up a [redirect](https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file) so for /predicate/chains to Chains documentation. 

i.e. `https://tekton.dev/predicate/chains/slsa/v2` -> `https://github.com/tektoncd/chains/tree/main/docs/predicate/slsa/v2`
(these pages don't actually exist yet).


This is a placeholder for SLSA predicate type documentation. We may try to figure out how to handle these better with the doc import process later on, but we need these to keep URL structure that AFAIK sync.py doesn't support well today. These URLs show up in Chains-generated SLSA predicates. 

We do not need navigation for these URLs (we'll figure out if we want to add this later with the doc syncing).

See https://github.com/tektoncd/chains/pull/906 for more details.

Fixes #561 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
