### PR TITLE
Minor rewording in tasks.md

### DIFF
--- a/content/en/docs/Getting-started/tasks.md
+++ b/content/en/docs/Getting-started/tasks.md
@@ -131,7 +131,7 @@ running in its own container.
     kubectl apply --filename hello-world.yaml
     ```
 
-      The output confirms that the Task was completed successfully:
+      The output confirms that the Task was created successfully:
 
       ```
       task.tekton.dev/hello created


### PR DESCRIPTION
When creating a task, the text says that the output confirms that the task completed successfully, while the task did not run yet as a TaskRun object was not created yet.

Changing the text so it imply that the task resource was created instead.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
