### PR TITLE
Fix doc error in Getting Started Supply Chain Security guide

### DIFF
--- a/content/en/docs/Getting-started/samples/build-push.yaml
+++ b/content/en/docs/Getting-started/samples/build-push.yaml
@@ -44,7 +44,7 @@ spec:
     workingDir: $(workspaces.source.path)
     image: bash
     script: |
-      cat <<EOF > Dockerfile
+      cat <<EOF > $(workspaces.source.path)/Dockerfile
       FROM alpine:3.16
       RUN echo "hello world" > hello.log
       EOF

--- a/content/en/docs/Getting-started/supply-chain-security.md
+++ b/content/en/docs/Getting-started/supply-chain-security.md
@@ -289,6 +289,6 @@ PipelineRun built and pushed.
 [kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
 [tkn]: /docs/cli/
 [jq]: https://stedolan.github.io/jq/download/
-[cosign]: https://docs.sigstore.dev/cosign/installation/
+[cosign]: https://docs.sigstore.dev/cosign/system_config/installation/
 [blog-post]: /blog/2023/04/19/getting-to-slsa-level-2-with-tekton-and-tekton-chains/
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Couple of small changes to the documentation for the Getting Started Supply Chain Security guide

1. Fix broken link for co-sign.
2. Pipeline run was failing with [kaniko-build : build-and-push] error building image: parsing dockerfile: Dockerfile parse error line 3: unknown instruction: EOF for create-dockerfile task. Added $(workspaces.source.path)/ for docker file creation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
