### PR TITLE
Fix local website deployment and update dev docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -47,10 +47,8 @@ docker-compose rm
 * [hugo v0.107.0 (EXTENDED VERSION)](https://github.com/gohugoio/hugo/releases/v0.107.0)
 * [pip](https://pip.pypa.io/en/stable/installing/)
 * [git 1.8.5 or later](https://github.com/git/git/releases)
-* [npm v6.14.5](https://nodejs.org/en/)
-* [node v14.3.0](https://nodejs.org/en/)
-* [netlify cli](https://cli.netlify.com/getting-started)
-* [netlify account](https://app.netlify.com/)
+* [npm v10.9.2](https://nodejs.org/en/)
+* [node v22.14.0](https://nodejs.org/en/)
 
 ### Setup
 
@@ -72,7 +70,6 @@ docker-compose rm
    python3 -m venv .venv
    source .venv/bin/activate    
    pip3 install -r requirements.txt
-
    ```
 
 1. Run the sync script
@@ -84,7 +81,7 @@ docker-compose rm
 1. Serve the website locally
 
    ```bash
-   netlify dev
+   npm start
    ```
 
 1. Verify that the website is working

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tekton documentation",
   "main": "none.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "netlify dev"
   },
   "repository": {
     "type": "git",
@@ -17,7 +17,8 @@
   },
   "homepage": "https://tekton.dev/",
   "devDependencies": {
-    "autoprefixer": "10.4.0",
+    "autoprefixer": "^10.4.0",
+    "netlify-cli": "^19.1.4",
     "postcss": "^8.3.7",
     "postcss-cli": "^9.1.0"
   }


### PR DESCRIPTION
# Changes

Following the ["Running Natively" guide](https://github.com/tektoncd/website/blob/main/DEVELOPMENT.md#running-natively) in the development docs does not work anymore because the [`netlify-cli` needs Node v18 or above](https://github.com/netlify/cli?tab=readme-ov-file#installation). The docs were updated to use Node v20.

Additionally the setup steps were simplified.

The `netlify-cli` has a fixed version in the package.json and is installed via `npm install` as a dev dependency. The dev server can then be started with `npm start`. There is no need to have a global installation of the `netlify-cli` anymore.

Closes issue #642.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
