### PR TITLE
Fix local dev environment setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 # Ignore node and python module directores when running in a container
 
 node_modules
+sync/.cache
+.netlify
 .venv

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -93,6 +93,10 @@ Please use the **exact versions** specified here otherwise `npm start` will fail
    documentation and those changes will immediately show up in the browser after
    you save.
 
+To debug issues only present in the production build, you can run the Netlify production build locally:
+
+`URL=http://localhost:8888 npx netlify serve`
+
 The `sync.py` script clones the required repositories to a local cache folder, by default `sync/.cache`.
 You can modify content and create commits in your local cache to test changes to the original docs.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM klakegg/hugo:ext-ubuntu as website
-RUN apt -y update && apt -y install git build-essential python3-venv python3-pip
+FROM klakegg/hugo:0.107.0-ext-ubuntu as website
+RUN apt-get -y update && apt-get -y install git build-essential python3-venv python3-pip
 COPY . /src
 RUN git config --global --add safe.directory /src
 RUN npm install
-RUN npm install -g netlify-cli
+RUN npm install -g netlify-cli@19.1.7
 
 RUN python3 -m venv .venv
 RUN . .venv/bin/activate

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,4 @@
-version: "3.3"
-
 services:
-
    site:
       image: tekton/website
       build:

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,7 +12,6 @@
 {{ partialCached "favicons.html" . }}
 <title>{{ if .IsHome }}{{ .Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}Tekton{{ end }}</title>
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 {{ if eq (getenv "HUGO_ENV") "production" }}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- Pin hugo image to correct version
- Pin netlify-cli to correct version
- Replace `apt` with `apt-get` to address warning about use in scripts
- Remove `version` field from docker-compose file to address warning
- Ignore sync cache and local netlify content for docker context to improve build speed
- Add instructions for running production build locally to help with debugging issues only encountered in the full Netlify production deploy, with plugins enabled etc.
- Remove the deprecated `google_news` partial to address that warning. It's been unsupported since 2017 and wasn't outputting anything anyway.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
