### PR TITLE
ISSUE-709: Update Hugo to v0.120.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,7 +46,7 @@ docker-compose rm
 Please use the **exact versions** specified here otherwise `npm start` will fail.
 
 - [python3](https://www.python.org/downloads/)
-- [hugo v0.107.0 (EXTENDED VERSION)](https://github.com/gohugoio/hugo/releases/v0.107.0)
+- [hugo v0.120.0 (EXTENDED VERSION)](https://github.com/gohugoio/hugo/releases/v0.120.0)
 - [pip](https://pip.pypa.io/en/stable/installing/)
 - [git 1.8.5 or later](https://github.com/git/git/releases)
 - [npm v10.9.2](https://nodejs.org/en/)
@@ -70,7 +70,7 @@ Please use the **exact versions** specified here otherwise `npm start` will fail
 
    ```bash
    python3 -m venv .venv
-   source .venv/bin/activate    
+   source .venv/bin/activate
    pip3 install -r requirements.txt
    ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,88 @@
-FROM klakegg/hugo:0.107.0-ext-ubuntu as website
-RUN apt-get -y update && apt-get -y install git build-essential python3-venv python3-pip
-COPY . /src
-RUN git config --global --add safe.directory /src
-RUN npm install
-RUN npm install -g netlify-cli@19.1.7
+# Build stage - includes build tools
+FROM python:3.11.15 AS builder
 
-RUN python3 -m venv .venv
-RUN . .venv/bin/activate
-RUN pip3 install -r requirements.txt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install build dependencies
+RUN apt-get -y update && apt-get -y install \
+    git \
+    build-essential \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 22.x
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/* && \
+    npm cache clean --force
+
+# Install Go 1.22 (required by Hugo for module downloads)
+RUN curl -L https://go.dev/dl/go1.22.0.linux-amd64.tar.gz -o go.tar.gz && \
+    tar -C /usr/local -xzf go.tar.gz && \
+    rm go.tar.gz
+ENV PATH="/usr/local/go/bin:$PATH"
+
+# Install Hugo v0.120.0
+RUN curl -L https://github.com/gohugoio/hugo/releases/download/v0.120.0/hugo_extended_0.120.0_linux-amd64.tar.gz -o hugo.tar.gz && \
+    tar -xzf hugo.tar.gz && \
+    mv hugo /usr/local/bin/ && \
+    rm hugo.tar.gz LICENSE README.md
+
+COPY requirements.txt /tmp/requirements.txt
+COPY package*.json /tmp/
+
+WORKDIR /tmp
+
+# Install Python packages
+RUN pip install --no-cache-dir -r requirements.txt
+
+
+# Runtime stage - minimal dependencies
+FROM python:3.11.15 AS website
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install only runtime dependencies (no build-essential)
+RUN apt-get -y update && apt-get -y install \
+    git \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 22.x (runtime only, no build tools)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/* && \
+    npm cache clean --force
+
+# Copy Go from builder
+COPY --from=builder /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:$PATH"
+
+# Copy Hugo from builder
+COPY --from=builder /usr/local/bin/hugo /usr/local/bin/hugo
+
+# Copy Python packages from builder
+COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+
+COPY . /src
+WORKDIR /src
+
+# Install npm packages (local dependencies and netlify-cli globally)
+RUN npm install && \
+    npm install -g netlify-cli@19.1.7 && \
+    npm cache clean --force
+
+RUN git config --global --add safe.directory /src
+
+# Remove system python3 symlink and replace with python from container
+# This ensures python3 always points to /usr/local/bin/python3 (3.11) even when PATH is modified
+# netlify prepends /usr/bin to PATH, so we need to ensure python3 is available there
+RUN rm /usr/bin/python3 && ln -s /usr/local/bin/python3 /usr/bin/python3
+
+# Configure Netlify to bind to 0.0.0.0 so it's accessible from outside the container
+ENV NETLIFY_DEV_HOST=0.0.0.0
 
 ENTRYPOINT ["/usr/bin/netlify"]
 CMD ["dev"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
       image: tekton/website
       build:
          context: .
-      ports: 
+      ports:
          - '8888:8888'
       volumes:
          - /src/content/en/docs/Chains/

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "make production-build"
 
 [build.environment]
-  HUGO_VERSION = "0.107.0"
+  HUGO_VERSION = "0.120.0"
 
 [context.production.environment]
   HUGO_ENV = "production"


### PR DESCRIPTION
Fixes rendering emojis in code blocks.
Update Hugo to never version.
- Hugo updated to v0.120.0
- Dockerfile based on python:3.11.15 instead klakegg/hugo:0.107.0-ext-ubuntu

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

So we need Hugo version >= v0.120.0 to fix the issue with [rendering emojis in code blocks](https://github.com/tektoncd/pipeline/issues/6822) .

Originally Docker image was based on klakegg/hugo images based on ubuntu but the newest image is there for version 0.111.3
which is not enough to fix the problem.

Current official images for hugo are available as ghcr.io/gohugoio/hugo but those are based on alpine, unfortunately netlify requires Deno (Netlify Edge Functions) and Deno dont support Alpine Linux (musl libc) https://github.com/denoland/deno/issues/3711.

So I tried to install everything from scratch on ubuntu based image.
This leads me to install newest hugo version (v0.159.0).

But this time Docsy v0.6.0 is not compatible with newest version of Hugo (highest verion hugo that supports Docsy 0.6.0 is v0.128.x)
Website with Hugo version v0.128.x has some bugs (Few sections disappeared on the left navigation bar) so at the end I leave version v0.120.0 that seems to work fine.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
