### PR TITLE
docs: Add Pipelines-as-Code to docs sidebar navigation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -88,27 +88,30 @@ menu:
     - name: "Tasks and Pipelines"
       url: "/docs/pipelines/"
       weight: 5
+    - name: "Pipelines-as-Code"
+      url: "/docs/pipelines-as-code/"
+      weight: 6
     - name: "Triggers and EventListeners"
       url: "/docs/triggers/"
-      weight: 6
+      weight: 7
     - name: "Command-Line Interface"
       url: "/docs/cli/"
-      weight: 7
+      weight: 8
     - name: "Supply Chain Security"
       url: "/docs/chains/"
-      weight: 8
+      weight: 9
     - name: "Operator"
       url: "/docs/operator/"
-      weight: 9
+      weight: 10
     - name: "Dashboard"
       url: "/docs/dashboard/"
-      weight: 10 
+      weight: 11
     - name: "Results"
       url: "/docs/results/"
-      weight: 11
+      weight: 12
     - name: "Pruner"
       url: "/docs/pruner/"
-      weight: 12
+      weight: 13
     - name: "Contribute"
       url: "/docs/contribute/"
       weight: 100 

--- a/content/en/docs/Pipelines-as-Code/_index.md
+++ b/content/en/docs/Pipelines-as-Code/_index.md
@@ -1,0 +1,18 @@
+<!--
+---
+title: "Pipelines-as-Code"
+linkTitle: "Pipelines-as-Code"
+weight: 6
+description: >
+  Git-native CI/CD with Tekton
+---
+-->
+
+Pipelines-as-Code brings a Git-native CI/CD experience to Tekton. Define your
+pipeline definitions as code in your repository and have them automatically
+triggered by events such as pull requests and pushes.
+
+Pipelines-as-Code supports GitHub, GitLab, Bitbucket, and other Git providers.
+
+Full documentation is available at
+[pipelinesascode.com/docs](https://pipelinesascode.com/docs/).


### PR DESCRIPTION
## Summary
- Add a top-level "Pipelines-as-Code" entry to the docs sidebar, placed right after "Tasks and Pipelines"
- Create a landing page at `/docs/pipelines-as-code/` with a description and link to the external documentation at https://pipelinesascode.com/docs/
- Bump weights of subsequent sidebar entries to maintain ordering

## Test plan
- [ ] Run `hugo server` and verify "Pipelines-as-Code" appears in the sidebar after "Tasks and Pipelines"
- [ ] Click the sidebar link and confirm the landing page loads correctly
- [ ] Verify the external link to pipelinesascode.com/docs/ works
- [ ] Confirm all other sidebar entries still render in the correct order

🤖 Generated with [Claude Code](https://claude.com/claude-code)