### PR TITLE
Fix blank sidebar items when linkTitle/title is missing

### DIFF
--- a/layouts/partials/sidebar-tree-docs.html
+++ b/layouts/partials/sidebar-tree-docs.html
@@ -54,7 +54,7 @@
 							 {{- $link := cond (isset .Params "manuallink") .Params.manualLink .RelPermalink -}}
 							<li class="td-sidebar-nav__section-title td-sidebar-nav__section without-child{{ if $active }} active-path{{ end }}" id="{{ $mid }}-li">
 							 <input type="checkbox" id="{{ $mid }}-check"{{ if $active}} checked{{ end }}/>
-							 <label for="{{ $mid }}-check"><a class="align-left pl-0 {{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__page" id="{{ $mid }}" href="{{ $link }}"{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}><span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}"> {{ .LinkTitle }}</span></a></label>
+							 <label for="{{ $mid }}-check"><a class="align-left pl-0 {{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__page" id="{{ $mid }}" href="{{ $link }}"{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}><span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}"> {{ if .LinkTitle }}{{ .LinkTitle }}{{ else if .Title }}{{ .Title }}{{ else }}{{ .File.BaseFileName }}{{ end }}</span></a></label>
 							</li>
             </li>
            {{- end -}}


### PR DESCRIPTION
Fixes #720

## Changes

Fixes an issue where some sidebar items were rendered as blank (clickable but with no visible text).

This occurred when `linkTitle` and `title` were missing in certain synced documentation pages.

Added a fallback in the sidebar template:
- Use `.LinkTitle` if available
- Else `.Title`
- Else fallback to `.File.BaseFileName`

This ensures all sidebar items are visible even when metadata is missing.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._