### PR TITLE
Add Pipelines v1.15.x to website sync configuration

### DIFF
--- a/sync/config/pipelines.yaml
+++ b/sync/config/pipelines.yaml
@@ -8,6 +8,15 @@ repository: https://github.com/tektoncd/pipeline
 archive: https://github.com/tektoncd/pipeline/tags
 # See support versions in pipelines releases.md: https://github.com/tektoncd/pipeline/blob/main/releases.md
 tags:
+- name: release-v1.15.x
+  displayName: v1.15.x-LTS
+  folders:
+    docs:
+      index: README.md
+      include: ['*.md']
+      exclude:
+        - api-spec.md
+        - tutorial.md
 - name: release-v1.12.x
   displayName: v1.12.x-LTS
   folders:


### PR DESCRIPTION
# Changes

Add `release-v1.15.x` branch to the Pipelines sync configuration so that v1.15.x docs are published to tekton.dev.

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)