### PR TITLE
docs: update pac docs links on website

### DIFF
--- a/content/en/docs/Pipelines-as-Code/_index.md
+++ b/content/en/docs/Pipelines-as-Code/_index.md
@@ -15,4 +15,4 @@ triggered by events such as pull requests and pushes.
 Pipelines-as-Code supports GitHub, GitLab, Bitbucket, and other Git providers.
 
 Full documentation is available at
-[pipelinesascode.com/docs](https://pipelinesascode.com/docs/).
+[pipelinesascode.com](https://pipelinesascode.com).


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
this remove /docs path from PaC docs link and URL now points to home page of documentation.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/website/blob/master/CONTRIBUTING.md)
for more details._
